### PR TITLE
Handle samplesheet input

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Currently, the available placeholder inputs include the following:
 - `INPUT-R1-R2`: indicates to pass all R1 AND R2 fastq files as input
 - `INPUT-SAMPLE-PREFIX`: if to pass string input of sample name prefix split on `'sample_name_delimeter'` if specified in config
 - `INPUT-SAMPLE-NAME`: if to pass string input of sample name
+- `INPUT-SAMPLESHEET`: passes the samplesheet associated to the sentinel file (or provided with `-iSAMPLESHEET`) as an input, must be structured in the `inputs` section of the config as: `{"$dnanexus_link": "INPUT-SAMPLESHEET"}`
 - `INPUT-dx_project_id`: pass the project id used for analysis
 - `INPUT-dx_project_name`: pass the project name used for analysis
 - `INPUT-analysis_X-out_dir`: pass the output directory of analysis `X` as input, where `X` is the number of the analysis defined as above (used when an app takes a path to a directory as input)

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -453,8 +453,11 @@ class TestAddOtherInputs():
         },
         "sample_name_prefix": "INPUT-SAMPLE-PREFIX",
         "sample_name": "INPUT-SAMPLE-NAME",
-        "output_path": "INPUT-analysis_1-out_dir"
-    }
+        "output_path": "INPUT-analysis_1-out_dir",
+        "run_sample_sheet": {
+            "$dnanexus_link": "INPUT-SAMPLESHEET"
+        },
+}
 
     # set up argparse namespace with required variables
     args = Namespace()
@@ -465,6 +468,11 @@ class TestAddOtherInputs():
     analysis_output_directories = {
         "analysis_1": "/output/some_assay-220930-1200/my_first_app"
     }
+
+    # set samplesheet file ID as env variable as set in eggd_conductor.sh
+    os.environ['SAMPLESHEET'] = (
+        "{'$dnanexus_link': 'file-GGxPVxQ4X7kbkFBx7b913b0G'}"
+    )
 
     # call add_other_inputs() to replace all INPUT-s
     output = ManageDict().add_other_inputs(
@@ -527,6 +535,20 @@ class TestAddOtherInputs():
         assert self.output['output_path'] == correct_path, (
             'INPUT-analysis_1-out_dir not correctly replaced'
         )
+    
+    def test_adding_samplesheet(self):
+        """
+        Test for finding and replacing INPUT-SAMPLESHEET from SAMPLESHEET
+        environment variable which will be the dnanexus file ID
+        """
+        correct_samplesheet = {
+            '$dnanexus_link': 'file-GGxPVxQ4X7kbkFBx7b913b0G'
+        }
+
+        assert self.output['run_sample_sheet'] == correct_samplesheet, (
+            'Samplesheet not correctly parsed to input dict'
+        )
+
 
 
 class TestGetDependentJobs():

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from pprint import PrettyPrinter
+import os
 import re
 
 from flatten_json import flatten, unflatten_list
@@ -106,7 +107,7 @@ class ManageDict():
             # track if we found a match and already key added to output dict
             added_key = False
 
-            if not isinstance(replacing, bool) and replacing:
+            if isinstance(replacing, str) and replacing:
                 for match in matches:
                     if not match in replacing:
                         continue
@@ -226,6 +227,7 @@ class ManageDict():
             - project id (INPUT-dx_project_id)
             - project name (INPUT-dx_project_name)
             - parent output directory (INPUT-parent_out_dir)
+            - samplesheet (INPUT-SAMPLESHEET)
 
         Parameters
         ----------
@@ -272,13 +274,23 @@ class ManageDict():
         # removing /output/ for now to fit to MultiQC
         args.parent_out_dir = args.parent_out_dir.replace('/output/', '')
 
+        samplesheet = ""
+        if os.environ.get('SAMPLESHEET'):
+            # get just the ID of samplesheet in case of being formatted as
+            # {'$dnanexus_link': 'file_id'}
+            match = re.search('file-[\d\w]*', os.environ.get('SAMPLESHEET'))
+            if match:
+                samplesheet = match.group()
+
+
         # mapping of potential user defined keys and variables to replace with
         to_replace = [
             ('INPUT-SAMPLE-NAME', sample),
             ('INPUT-SAMPLE-PREFIX', sample_prefix),
             ('INPUT-dx_project_id', args.dx_project_id),
             ('INPUT-dx_project_name', args.dx_project_name),
-            ('INPUT-parent_out_dir', args.parent_out_dir)
+            ('INPUT-parent_out_dir', args.parent_out_dir),
+            ('INPUT-SAMPLESHEET', samplesheet)
         ]
 
         for pair in to_replace:


### PR DESCRIPTION
## Summary

Adds extra optional input of samplesheet as `INPUT-SAMPLESHEET` for apps (currently required by [update_runfolders](https://github.com/eastgenomics/eggd_update_runfolders)).

Example conductor job: https://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/job/GJ2b8XQ4Bv4F4b95139ggvX9

Dias multi job with samplesheet parsed: https://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/analysis/GJ2b9kQ4Bv45Y56p8yfGz8Zy

```
jethro@jethro-T490:~/Projects/eggd_conductor$ python3 -m pytest -v --disable-pytest-warnings resources/home/dnanexus/run_workflows/tests/ 
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/eggd_conductor
plugins: Faker-14.0.0, mock-3.9.0, cov-4.0.0
collected 44 items                                                                                                                                          

resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_key_return_key_level1 PASSED                             [  2%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_key_return_value_level1 PASSED                           [  4%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_key_return_array_values PASSED                           [  6%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_dict_array PASSED                                        [  9%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestReplaceDict::test_replace_level1_keys PASSED                                     [ 11%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestReplaceDict::test_replace_all_value1 PASSED                                      [ 13%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestReplaceDict::test_replace_value_from_key PASSED                                  [ 15%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_all_r1 PASSED                                             [ 18%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_all_r2 PASSED                                             [ 20%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_all_r1_and_r2 PASSED                                      [ 22%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_per_sample_r1_fastqs PASSED                               [ 25%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_per_sample_r2_fastqs PASSED                               [ 27%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_assert_equal_number_fastqs PASSED                                [ 29%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_assert_found_fastqs PASSED                                       [ 31%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_sample_name PASSED                                   [ 34%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_sample_prefix PASSED                                 [ 36%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_project_id PASSED                                    [ 38%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_project_name PASSED                                  [ 40%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_parent_out_dir PASSED                                [ 43%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_analysis_1_out_dir PASSED                            [ 45%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_samplesheet PASSED                                   [ 47%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_per_sample_w_per_run_dependent_job PASSED                 [ 50%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_per_run_get_analysis_1_jobs PASSED                        [ 52%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_per_run_get_all_jobs PASSED                               [ 54%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_absent_analysis_does_not_raise_error PASSED               [ 56%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_absent_analysis_does_not_raise_error_per_sample PASSED    [ 59%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestLinkInputsToOutputs::test_adding_all_analysis_1 PASSED                           [ 61%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestLinkInputsToOutputs::test_adding_one_sample_analysis_1 PASSED                    [ 63%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestLinkInputsToOutputs::test_parse_output_of_per_run_job PASSED                     [ 65%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestPopulateOutputDirConfig::test_populate_app_output_dirs PASSED                    [ 68%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestPopulateOutputDirConfig::test_populate_workflow_output_dirs PASSED               [ 70%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestPopulateOutputDirConfig::test_not_replacing_hard_coded_paths PASSED              [ 72%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestFilterJobOutputsDict::test_filter_job_outputs_dict_one_pattern PASSED            [ 75%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestFilterJobOutputsDict::test_filter_multiple_patterns PASSED                       [ 77%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckInputClasses::test_array_input_with_single_dict_given PASSED                [ 79%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckInputClasses::test_file_input_with_array_length_one_given PASSED            [ 81%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckInputClasses::test_file_input_with_array_length_over_one PASSED             [ 84%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckAllInputs::test_find_unparsed_input PASSED                                  [ 86%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckAllInputs::test_find_unparsed_analysis PASSED                               [ 88%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::test_parse_sample_sheet PASSED                                                     [ 90%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::test_parse_run_info_xml PASSED                                                     [ 93%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::TestMatchSamplesToAssays::test_return_single_assay PASSED                          [ 95%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::TestMatchSamplesToAssays::test_raise_assertion_error_on_mixed_assays PASSED        [ 97%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::TestMatchSamplesToAssays::test_raise_assertion_error_on_sample_w_no_assay_code_match PASSED [100%]

==================================================================== 44 passed in 1.49s =====================================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/8)
<!-- Reviewable:end -->
