### PR TITLE
Handle upload tars as input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ test_configs/*
 *.pyc
 *ipynb
 *.log
+*.cfg

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Currently, the available placeholder inputs include the following:
 - `INPUT-R1`: indicates to pass 1 or more R1 fastq files as input
 - `INPUT-R2`: indicates to pass 1 or more R2 fastq files as input
 - `INPUT-R1-R2`: indicates to pass all R1 AND R2 fastq files as input
+- `INPUT-UPLOAD_TARS`: provide upload tars associated to sentinel record as an input
 - `INPUT-SAMPLE-PREFIX`: if to pass string input of sample name prefix split on `'sample_name_delimeter'` if specified in config
 - `INPUT-SAMPLE-NAME`: if to pass string input of sample name
 - `INPUT-SAMPLESHEET`: passes the samplesheet associated to the sentinel file (or provided with `-iSAMPLESHEET`) as an input, must be structured in the `inputs` section of the config as: `{"$dnanexus_link": "INPUT-SAMPLESHEET"}`

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -11,11 +11,8 @@ inputs are valid.
 """
 import argparse
 from collections import defaultdict
-from re import search
-import re
 from xml.etree import ElementTree as ET
 import json
-import sys
 
 import dxpy as dx
 import pandas as pd

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -381,13 +381,14 @@ def main():
             "and re-run"
         )
 
+    fastq_details = []
+
     if args.bcl2fastq_id:
         # previous bcl2fastq job specified to use fastqs from
         fastq_details = dx_manage.get_bcl2fastq_details(args.bcl2fastq_id)
     elif args.fastqs:
         # fastqs specified to start analysis from, call describe on
         # files to get name and build list of tuples of (file id, name)
-        fastq_details = []
         for fastq_id in args.fastqs:
             fastq_name = dx.api.file_describe(
                 fastq_id, input_params={'fields': {'name': True}}

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -361,13 +361,12 @@ def main():
     parent_out_dir = f"/output/{args.assay_name}-{run_time}"
     args.parent_out_dir = parent_out_dir
 
+    # get upload tars from sentinel file, abuse argparse Namespace object
+    # again to make it simpler to pass through to DXExecute / DXManage
+    args.upload_tars = DXManage(args).get_upload_tars()
+
     dx_execute = DXExecute(args)
     dx_manage = DXManage(args)
-
-    # get upload tars from sentinel file
-    upload_tars = dx_manage.get_upload_tars()
-    if upload_tars:
-        args.upload_tars = upload_tars
 
     # sense check per_sample defined for all workflows / apps in config before
     # starting as we want this explicitly defined for everything to ensure

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -437,6 +437,45 @@ class TestAddFastqs():
             )
 
 
+class TestAddUploadTars():
+    """
+    Tests for adding upload tars to input dict
+    """
+    input_dict = {
+        "TSO500_ruo": {
+            "$dnanexus_link": "file-Fz4X61Q44Bv44FyfJX1jJPj6"
+        },
+        "samplesheet": {
+            "$dnanexus_link": "INPUT-SAMPLESHEET"
+        },
+        "input_files": "INPUT-UPLOAD_TARS"
+    }
+
+    # formatted as returned from DXManage.get_upload_tars
+    upload_tars = [
+        {'$dnanexus_link': 'file-GGyq26j4X7kXxJ0fG5PF08jy'},
+        {'$dnanexus_link': 'file-GGyq6y84X7kYPFVBG89bBBF7'},
+        {'$dnanexus_link': 'file-GGyq94j4X7kp6xB0GGx3q864'},
+        {'$dnanexus_link': 'file-GGyqFPQ4X7kqFx1bG6596qqQ'},
+        {'$dnanexus_link': 'file-GGyqK2j4X7kzzFfbGKBk8Xgp'},
+        {'$dnanexus_link': 'file-GGyqXp04X7kb7zV99ZYV3k9b'},
+        {'$dnanexus_link': 'file-GGyqgF84X7kY0fjZBk6jb68P'}
+    ]
+
+    parsed_dict = ManageDict().add_upload_tars(
+        input_dict=input_dict,
+        upload_tars=upload_tars
+    )
+
+    def test_adding_upload_tars(self):
+        """
+        Test that INPUT-UPLOAD_TARS is replaced by the list of file IDs
+        """
+        assert self.parsed_dict.get("input_files") == self.upload_tars, (
+            "Upload tars not correctly added to input dict"
+        )
+
+
 class TestAddOtherInputs():
     """
     Tests for add_other_inputs() used to gather up all random INPUT-
@@ -548,7 +587,6 @@ class TestAddOtherInputs():
         assert self.output['run_sample_sheet'] == correct_samplesheet, (
             'Samplesheet not correctly parsed to input dict'
         )
-
 
 
 class TestGetDependentJobs():

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -185,7 +185,7 @@ class DXExecute():
             job_handle = dx.bindings.dxapp.DXApp(dxid=executable).run(
                 app_input=input_dict,
                 project=self.args.dx_project_id,
-                folder=output_dict[executable],
+                folder=output_dict.get(executable),
                 ignore_reuse=True,
                 depends_on=prev_jobs,
                 name=job_name
@@ -194,7 +194,7 @@ class DXExecute():
             job_handle = dx.bindings.dxapplet.DXApplet(dxid=executable).run(
                 applet_input=input_dict,
                 project=self.args.dx_project_id,
-                folder=output_dict[executable],
+                folder=output_dict.get(executable),
                 ignore_reuse=True,
                 depends_on=prev_jobs,
                 name=job_name

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
@@ -401,6 +402,13 @@ class DXExecute():
 
         if params["process_fastqs"] is True:
             input_dict = ManageDict().add_fastqs(input_dict, fastq_details)
+        
+        # add upload tars as input if INPUT-UPLOAD_TARS present
+        if self.args.upload_tars:
+            input_dict = ManageDict().add_upload_tars(
+                input_dict=input_dict,
+                upload_tars=self.args.upload_tars
+            )
 
         # handle other inputs defined in config to add to inputs
         input_dict = ManageDict().add_other_inputs(
@@ -537,7 +545,7 @@ class DXManage():
             # add config to dict if not already present or newer one found
             all_configs[assay_code] = current_config
 
-        print(f"Found config files for assays: {', '.join(all_configs.keys())}")
+        print(f"Found config files for assays: {', '.join(sorted(all_configs.keys()))}")
 
         return all_configs
 
@@ -730,6 +738,35 @@ class DXManage():
         print(''.join([f'\t{x}\n' for x in fastq_details]))
 
         return fastq_details
+
+
+    def get_upload_tars(self) -> list:
+        """
+        Get list of upload tar file IDs from given sentinel file,
+        and return formatted as a list of $dnanexus_link dicts
+
+        Returns
+        -------
+        list
+            list of file ids formated as {"$dnanexus_link": file-xxx}
+        """
+        sentinel_id = os.environ.get('SENTINEL_FILE_ID')
+
+        if not sentinel_id:
+            # sentinel file not provided as input -> can't get tars
+            return None
+
+        details = dx.bindings.dxrecord.DXRecord(
+            dxid=sentinel_id).describe(incl_details=True)
+        
+        upload_tars = details['details']['tar_file_ids']
+
+        # format in required format for a dx input
+        upload_tars = [
+            {"$dnanexus_link": x} for x in upload_tars
+        ]
+
+        return upload_tars
 
 
     def get_executable_names(self, executables) -> dict:

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1,3 +1,4 @@
+from argparse import Namespace
 from copy import deepcopy
 from pprint import PrettyPrinter
 import os
@@ -211,6 +212,32 @@ class ManageDict():
                 r1_r2_input.extend([{"$dnanexus_link": x[0]} for x in r1_fastqs])
                 r1_r2_input.extend([{"$dnanexus_link": x[0]} for x in r2_fastqs])
                 input_dict[stage] = r1_r2_input
+
+        return input_dict
+
+
+    def add_upload_tars(self, input_dict, upload_tars) -> dict:
+        """
+        Add list of upload tars parsed from sentinel record as input
+        as defined by INPUT-UPLOAD_TARS
+
+        Parameters
+        ----------
+        input_dict : dict
+            dict of input parameters for calling workflow / app
+
+        Returns
+        -------
+        input_dict : dict
+            dict of input parameters for calling workflow / app
+        """
+        input_dict = self.replace(
+            input_dict=input_dict,
+            to_replace='INPUT-UPLOAD_TARS',
+            replacement=upload_tars,
+            search_key=False,
+            replace_key=False
+        )
 
         return input_dict
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -231,13 +231,9 @@ class ManageDict():
         input_dict : dict
             dict of input parameters for calling workflow / app
         """
-        input_dict = self.replace(
-            input_dict=input_dict,
-            to_replace='INPUT-UPLOAD_TARS',
-            replacement=upload_tars,
-            search_key=False,
-            replace_key=False
-        )
+        for input, value in input_dict.items():
+            if value == 'INPUT-UPLOAD_TARS':
+                input_dict[input] = upload_tars
 
         return input_dict
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1,4 +1,3 @@
-from argparse import Namespace
 from copy import deepcopy
 from pprint import PrettyPrinter
 import os

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -92,6 +92,9 @@ _parse_sentinel_file () {
         RUN_ID=$(jq -r '.details.run_id' <<< "$sentinel_details")
     fi
 
+    # set file ID of sentinel record to env to pick up in run_workflows.py
+    export SENTINEL_FILE_ID="$sentinel_id"
+
     if [ "$SAMPLESHEET" ]; then
         # samplesheet specified as input arg
         dx download -f "$SAMPLESHEET" -o SampleSheet.csv

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -280,7 +280,7 @@ main () {
         message+="/monitor/job/${PARENT_JOB_ID/job-/}"
         if [ -s analysis_project.log ]; then
             # analysis project was created, add to alert
-            read -r project_name project_id < analysis_project.log
+            read -r project_id _ _ < analysis_project.log
             message+="%0AAnalysis project: "
             message+="platform.dnanexus.com/projects/${project_id/project-/}/monitor/"
         fi


### PR DESCRIPTION
## Summary

Add another input for the config file of `INPUT-UPLOAD_TARS` to allow passing upload tars associated to sentinel file as an input.
This will allow for launching TSO500 app.

Other minor changes:
- made matching of samples to configs case insensitive to account for `egg` vs `EGG`
- fix bug in URL of Slack alert sent on fail from bash script

Example conductor job: https://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/job/GJ49q384Bv49VXxz4FkfXP8Q
Example TSO500 job launched : https://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/job/GJ49qP04Bv43x33499qkpg2x

Tests:
```
$ python3 -m pytest -v --disable-pytest-warnings resources/home/dnanexus/run_workflows/tests/ 
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.10, pytest-7.0.1, pluggy-1.0.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /home/jethro/Projects/eggd_conductor
plugins: Faker-14.0.0, mock-3.9.0, cov-4.0.0
collected 45 items                                                                                                                                          

resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_key_return_key_level1 PASSED                             [  2%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_key_return_value_level1 PASSED                           [  4%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_key_return_array_values PASSED                           [  6%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestSearchDict::test_search_dict_array PASSED                                        [  8%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestReplaceDict::test_replace_level1_keys PASSED                                     [ 11%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestReplaceDict::test_replace_all_value1 PASSED                                      [ 13%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestReplaceDict::test_replace_value_from_key PASSED                                  [ 15%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_all_r1 PASSED                                             [ 17%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_all_r2 PASSED                                             [ 20%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_all_r1_and_r2 PASSED                                      [ 22%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_per_sample_r1_fastqs PASSED                               [ 24%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_adding_per_sample_r2_fastqs PASSED                               [ 26%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_assert_equal_number_fastqs PASSED                                [ 28%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddFastqs::test_assert_found_fastqs PASSED                                       [ 31%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddUploadTars::test_adding_upload_tars PASSED                                    [ 33%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_sample_name PASSED                                   [ 35%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_sample_prefix PASSED                                 [ 37%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_project_id PASSED                                    [ 40%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_project_name PASSED                                  [ 42%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_parent_out_dir PASSED                                [ 44%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_analysis_1_out_dir PASSED                            [ 46%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestAddOtherInputs::test_adding_samplesheet PASSED                                   [ 48%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_per_sample_w_per_run_dependent_job PASSED                 [ 51%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_per_run_get_analysis_1_jobs PASSED                        [ 53%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_per_run_get_all_jobs PASSED                               [ 55%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_absent_analysis_does_not_raise_error PASSED               [ 57%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestGetDependentJobs::test_absent_analysis_does_not_raise_error_per_sample PASSED    [ 60%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestLinkInputsToOutputs::test_adding_all_analysis_1 PASSED                           [ 62%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestLinkInputsToOutputs::test_adding_one_sample_analysis_1 PASSED                    [ 64%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestLinkInputsToOutputs::test_parse_output_of_per_run_job PASSED                     [ 66%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestPopulateOutputDirConfig::test_populate_app_output_dirs PASSED                    [ 68%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestPopulateOutputDirConfig::test_populate_workflow_output_dirs PASSED               [ 71%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestPopulateOutputDirConfig::test_not_replacing_hard_coded_paths PASSED              [ 73%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestFilterJobOutputsDict::test_filter_job_outputs_dict_one_pattern PASSED            [ 75%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestFilterJobOutputsDict::test_filter_multiple_patterns PASSED                       [ 77%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckInputClasses::test_array_input_with_single_dict_given PASSED                [ 80%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckInputClasses::test_file_input_with_array_length_one_given PASSED            [ 82%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckInputClasses::test_file_input_with_array_length_over_one PASSED             [ 84%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckAllInputs::test_find_unparsed_input PASSED                                  [ 86%]
resources/home/dnanexus/run_workflows/tests/test_manage_dict.py::TestCheckAllInputs::test_find_unparsed_analysis PASSED                               [ 88%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::test_parse_sample_sheet PASSED                                                     [ 91%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::test_parse_run_info_xml PASSED                                                     [ 93%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::TestMatchSamplesToAssays::test_return_single_assay PASSED                          [ 95%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::TestMatchSamplesToAssays::test_raise_assertion_error_on_mixed_assays PASSED        [ 97%]
resources/home/dnanexus/run_workflows/tests/test_run_workflows.py::TestMatchSamplesToAssays::test_raise_assertion_error_on_sample_w_no_assay_code_match PASSED [100%]

=============================================================== 45 passed, 1 warning in 1.51s ===============================================================
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/9)
<!-- Reviewable:end -->
