### PR TITLE
Fix parsing samplesheet from env

### DIFF
--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -302,13 +302,12 @@ class ManageDict():
         args.parent_out_dir = args.parent_out_dir.replace('/output/', '')
 
         samplesheet = ""
-        if os.environ.get('SAMPLESHEET'):
+        if os.environ.get('SAMPLESHEET_ID'):
             # get just the ID of samplesheet in case of being formatted as
             # {'$dnanexus_link': 'file_id'}
-            match = re.search(r'file-[\d\w]*', os.environ.get('SAMPLESHEET'))
+            match = re.search(r'file-[\d\w]*', os.environ.get('SAMPLESHEET_ID'))
             if match:
                 samplesheet = match.group()
-
 
         # mapping of potential user defined keys and variables to replace with
         to_replace = [

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -218,7 +218,7 @@ main () {
         _parse_fastqs
     fi
 
-    export SAMPLESHEET
+    export SAMPLESHEET_ID=$SAMPLESHEET
 
     # send a message to logs so we know something is starting
     conductor_job_url="platform.dnanexus.com/projects/${PROJECT_ID/project-/}"


### PR DESCRIPTION
Fix when samplesheet specified with `-iSAMPLESHEET` it wasn't correctly parsed
![image](https://user-images.githubusercontent.com/45037268/200299759-37f68f5e-af60-47da-9897-da787c96eb7e.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/18)
<!-- Reviewable:end -->
