### PR TITLE
add launched job IDs as app output

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -137,7 +137,15 @@
       "help": "Path to store demultiplexing output, if not given will default parent of sentinel file. Should be in the format project:path"
     }
   ],
-  "outputSpec": [],
+  "outputSpec": [
+    {
+      "name": "job_ids",
+      "label": "job ids",
+      "class": "string",
+      "optional": true,
+      "help": "comma separated string of launched job IDs"
+    }
+  ],
   "runSpec": {
     "timeoutPolicy": {
       "*": {

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -459,6 +459,10 @@ def main():
 
     total_jobs = 0  # counter to write to final Slack message
 
+    # log file of all jobs, used to set as app output for picking up
+    # by separate monitoring script
+    open('all_job_ids.log', 'w').close()
+
     for executable, params in config['executables'].items():
         # for each workflow/app, check if its per sample or all samples and
         # run correspondingly

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -286,7 +286,12 @@ class DXExecute():
         log.info(f'Started analysis in project {self.args.dx_project_id}, job: {job_id}')
 
         with open('job_id.log', 'a') as fh:
+            # log of current executable jobs
             fh.write(f'{job_id} ')
+
+        with open('all_job_ids.log', 'a') as fh:
+            # log of all launched job IDs
+            fh.write(f'{job_id},')
 
         if self.args.testing:
             with open('testing_job_id.log', 'a') as fh:

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -336,5 +336,10 @@ main () {
     # tag conductor job with downstream project used for analysis
     dx tag "$PARENT_JOB_ID" "$analysis_project_url"
 
+    # set all job IDs as output
+    job_ids=$(cat all_job_ids.log)
+    job_ids="${job_ids%?}"  # trim off trailing comma
+    dx-jobutil-add-output job_ids "$job_ids" --class=string
+
     mark-success
 }


### PR DESCRIPTION
## Changes

Adds all launched job IDs as an output to the automation job to be picked up for monitoring

Example job: https://platform.dnanexus.com/projects/GJq6Bb04v59bqJyjGKXgkbkY/monitor/job/GKX66904v59bpVZq8K20pb5x

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/30)
<!-- Reviewable:end -->
