### PR TITLE
Fix adding upload tars as input

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,12 +1,9 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
-  "properties": {
-    "githubRelease": "v1.1.1"
-  },
   "inputSpec": [
     {
       "name": "EGGD_CONDUCTOR_CONFIG",

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -836,16 +836,16 @@ class DXManage():
         list
             list of file ids formated as {"$dnanexus_link": file-xxx}
         """
-        sentinel_id = os.environ.get('SENTINEL_FILE_ID')
-
-        if not sentinel_id:
-            # sentinel file not provided as input -> can't get tars
+        if not self.args.sentinel_file:
+            # sentinel file not provided as input -> no tars to parse
             return None
 
         details = dx.bindings.dxrecord.DXRecord(
-            dxid=sentinel_id).describe(incl_details=True)
-        
+            dxid=self.args.sentinel_file).describe(incl_details=True)
+
         upload_tars = details['details']['tar_file_ids']
+
+        log.info(f"Following upload tars found to add as input: {upload_tars}")
 
         # format in required format for a dx input
         upload_tars = [


### PR DESCRIPTION
Switch to getting sentinel record ID from argument instead of environment to be more robust

Fixes https://github.com/eastgenomics/eggd_conductor/issues/42

Test job: https://platform.dnanexus.com/projects/GQ0xPyj49GgpqvxvQb6kF08y/monitor/job/GQ0xYB849Ggb8PY91K3kP1px

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/43)
<!-- Reviewable:end -->
