### PR TITLE
make matching assay codes to samplenames case insensitive

### DIFF
--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -111,11 +111,12 @@ def match_samples_to_assays(configs, all_samples, testing) -> dict:
     """
     # build a dict of assay codes from configs found to samples based off
     # matching assay_code in sample names
-    all_config_assay_codes = [x.get('assay_code') for x in configs.values()]
+    all_config_assay_codes = sorted([
+        x.get('assay_code') for x in configs.values()])
     assay_to_samples = defaultdict(list)
 
-    log.info(f'All assay codes: {all_config_assay_codes}')
-    log.info(f'All samples: {all_samples}')
+    log.info(f'All assay codes of config files: {all_config_assay_codes}')
+    log.info(f'All samples parsed from samplesheet: {all_samples}')
 
     for code in all_config_assay_codes:
         for sample in all_samples:

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -120,7 +120,7 @@ def match_samples_to_assays(configs, all_samples, testing) -> dict:
 
     for code in all_config_assay_codes:
         for sample in all_samples:
-            if re.search(code, sample):
+            if re.search(code, sample, re.IGNORECASE):
                 assay_to_samples[code].append(sample)
 
     if not testing:

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -593,6 +593,8 @@ class DXManage():
             f'ASSAY_CONFIG_PATH from config appears invalid: {config_path}'
         )
 
+        log.info(f"Searching following path for assay configs: {config_path}")
+
         project, path = config_path.split(':')
 
         files = list(dx.find_data_objects(
@@ -601,6 +603,8 @@ class DXManage():
             project=project,
             folder=path
         ))
+
+        log.info(f"File IDs of JSON files found: {files}")
 
         # sense check we find config files
         assert files, Slack().send(


### PR DESCRIPTION
Fixes #44 

Example job: https://platform.dnanexus.com/projects/GQ0xPyj49GgpqvxvQb6kF08y/monitor/job/GQ0y4G849GgXBKz0gVK47VxG

From job logs showing matching `EGG6` assay code to `egg6` in samplenames:
![image](https://user-images.githubusercontent.com/45037268/222716574-f6fc05ec-079b-43a6-b8dd-01b14389ade1.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/45)
<!-- Reviewable:end -->
