### PR TITLE
demultiplexing fixes

### DIFF
--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -296,7 +296,6 @@ def parse_args() -> argparse.Namespace:
         args.run_id = parse_run_info_xml(args.run_info_xml)
 
     if not args.samples:
-        # TODO : sample sheet validation?
         args.samples = parse_sample_sheet(args.samplesheet)
 
     return args

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -140,7 +140,7 @@ _parse_sentinel_file () {
             _slack_notify "$message" "$SLACK_ALERT_CHANNEL"
             exit 1
         else
-            # found samplesheet in run data
+            # found samplesheet in run data, move it to parse sample names from in run_workflows.py
             mv "$local_samplesheet" /home/dnanexus/SampleSheet.csv
         fi
     fi

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -118,7 +118,6 @@ _parse_sentinel_file () {
     elif [ "$sentinel_samplesheet" != 'null' ]; then
         # samplesheet found during upload and associated to sentinel file
         dx download -f "$sentinel_samplesheet" -o SampleSheet.csv
-        SAMPLESHEET="$sentinel_samplesheet"
     else
         # sample sheet missing from sentinel file, most likely due to not being
         # named correctly, download the first tar, unpack and try to find it
@@ -132,19 +131,17 @@ _parse_sentinel_file () {
         # unpack tar and find samplesheet
         mkdir ./first_tar_dir
         tar -xzf first_tar.tar.gz -C ./first_tar_dir
-        SAMPLESHEET=$(find ./first_tar_dir -regextype posix-extended  -iregex '.*sample[-_ ]?sheet.csv$')
+        local_samplesheet=$(find ./first_tar_dir -regextype posix-extended  -iregex '.*sample[-_ ]?sheet.csv$')
 
-        if [ -z "$SAMPLESHEET" ]; then
+        if [ -z "$local_samplesheet" ]; then
             # sample sheet missing from root and first tar
             message="Sample sheet missing from runs dir and first tar, exiting now."
             dx-jobutil-report-error "$message"
             _slack_notify "$message" "$SLACK_ALERT_CHANNEL"
             exit 1
         else
-            # upload back to project in same dir as sentinel file to be able
-            # to get file ID for passing as input for INPUT-SAMPLESHEET
-            SAMPLESHEET=$(dx upload "$SAMPLESHEET" --path "$sentinel_path")
-            mv "$SAMPLESHEET" /home/dnanexus
+            # found samplesheet in run data
+            mv "$local_samplesheet" /home/dnanexus/SampleSheet.csv
         fi
     fi
 }
@@ -215,10 +212,13 @@ main () {
     fi
 
     if [ "$SAMPLESHEET" ]; then
+        # user specified samplesheet to use
         dx download -f "$SAMPLESHEET" -o SampleSheet.csv
+        export SAMPLESHEET_ID=$SAMPLESHEET
     fi
 
     if [ "$RUN_INFO_XML" ]; then
+        # user specified RunInfo.xml specified to use
         dx download -f "$RUN_INFO_XML" -o RunInfo.xml
     fi
 
@@ -231,8 +231,6 @@ main () {
         mark-section "running manually from provided FastQ files"
         _parse_fastqs
     fi
-
-    export SAMPLESHEET_ID=$SAMPLESHEET
 
     # send a message to logs so we know something is starting
     conductor_job_url="platform.dnanexus.com/projects/${PROJECT_ID/project-/}"


### PR DESCRIPTION
- better handling of failed demultiplexing jobs - fixes #40
- actually use given samplesheet for demultiplexing

Example notification for failed job:
![image](https://user-images.githubusercontent.com/45037268/223100119-0bb48d4e-fcf0-4b03-9402-7b9440dac80f.png)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/47)
<!-- Reviewable:end -->
