### PR TITLE
v1.3.0 - change default behaviour for project selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,8 @@ The following describe default app input behaviour:
 - `SAMPLESHEET` (optional): samplesheet used to parse sample names from, if not given this will be attempted to be located from the sentinel file properties first, then sentinel file run directory then the first upload tar file.
 - `FASTQS` (optional): array of fastq files, to use if not providing a sentinel file
 - `SAMPLE_NAMES` (optional): comma separated list of sample names, to use if not providing a samplesheet
-- `DX_PROJECT` (optional):  project ID in which to run and store output, if not specified will create a new project named as `002_<RUNID>_<ASSAY_CODE>` or `003_YYMMDD_<RUNID>_<ASSAY_CODE>` if `development=true`
+- `CREATE_PROJECT` (optional): controls if to create a downstream analysis project to launch analysis jobs in, default behaviour is to use same project as eggd_conductor is running in. If true, the app will create a new project named as `002_<RUNID>_<ASSAY_CODE>` or `003_YYMMDD_<RUNID>_<ASSAY_CODE>` if `DEVELOPMENT` is `true`
+- `DX_PROJECT` (optional):  project ID in which to run and store output
 - `RUN_ID` ( optional): ID of sequencing run used to name project, parsed from samplesheet if not specified
 - `DEVELOPMENT` (optional): Name output project with 003 prefix and date instead of 002_{RUN_ID}_{ASSAY} format
 - `TESTING` (optional): terminates all jobs and clears output files after launching - for testing use only

--- a/dxapp.json
+++ b/dxapp.json
@@ -81,6 +81,13 @@
       "help": "Project in which to run and store analysis outputs. \n If not given a new one will be created from the run ID and assay code."
     },
     {
+      "name": "CREATE_PROJECT",
+      "label": "Create project",
+      "class": "boolean",
+      "optional": true,
+      "help": "If to automatically create a downstream analysis project, default behaviour is to use the same project as eggd_conductor"
+    },
+    {
       "name": "RUN_ID",
       "label": "ID of sequencing run",
       "class": "string",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -85,6 +85,7 @@
       "label": "Create project",
       "class": "boolean",
       "optional": true,
+      "default": false,
       "help": "If to automatically create a downstream analysis project, default behaviour is to use the same project as eggd_conductor"
     },
     {

--- a/dxapp.json
+++ b/dxapp.json
@@ -86,7 +86,7 @@
       "class": "boolean",
       "optional": true,
       "default": false,
-      "help": "If to automatically create a downstream analysis project, default behaviour is to use the same project as eggd_conductor"
+      "help": "If to automatically create a downstream analysis project, default behaviour is to use the same project as eggd_conductor is currently running in"
     },
     {
       "name": "RUN_ID",

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -428,6 +428,11 @@ def main():
 
     args.dx_project_name = output_project
 
+    print(
+        f"\nUsing project {output_project} ({args.dx_project_id}) "
+        "for launching analysis jobs in\n"
+    )
+
     # set context to project for running jobs
     dx.set_workspace_id(args.dx_project_id)
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -267,6 +267,12 @@ main () {
         ASSAY_CONFIG_ID=$(grep -oE 'file-[A-Za-z0-9]+' <<< "$ASSAY_CONFIG")
         dx-jobutil-add-output assay_config_file_id "$ASSAY_CONFIG_ID" --class=file
     fi
+    if [[ "$CREATE_PROJECT" == 'false' && -z "$DX_PROJECT" ]]; then
+        # default behaviour to not create analysis project and use same as
+        # app is running in, set DX_PROJECT input to be same as current project
+        # if one has not been specified
+        optional_args+="--dx_project_id $PROJECT_ID "
+    fi
     if [ "$upload_sentinel_record" ]; then optional_args+="--sentinel_file ${sentinel_id} "; fi
     if [ -f "SampleSheet.csv" ]; then optional_args+="--samplesheet SampleSheet.csv "; fi
     if [ -f "RunInfo.xml" ]; then optional_args+="--run_info_xml RunInfo.xml "; fi


### PR DESCRIPTION
##Summary
Change to make default behaviour to launch analysis jobs in same project as conductor is running, this is to improve safety and stop accidentally running jobs in 002 projects.

Fixes #62 

## Changes
- New input `CREATE_PROJECT` (default: `false`) to control if to automatically create an analysis project

## Test jobs:
- No project specified (i.e. launch in same project): https://platform.dnanexus.com/projects/GVbfzG0409P6527X7PGXpV98/monitor/job/GVbg888409P0y5K5P55G9vK7 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/7c7084a3-1af3-41ca-b0f1-a6e6e9b99ac1)

 - DNAnexus project specified to use: https://platform.dnanexus.com/projects/GVbfzG0409P6527X7PGXpV98/monitor/job/GVbgBJ0409PFXF4pyF355fz1 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/773caab6-c6c5-4b90-8153-e780f47ba383)

- `CREATE_PROJECT=true` (i.e. automatically create an analysis project as will be done in production): https://platform.dnanexus.com/projects/GVbfzG0409P6527X7PGXpV98/monitor/job/GVbgJV8409P4202Vx6g7bfJZ  
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/798d6a30-8c52-4638-ab9b-a9a9543fb5a9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/73)
<!-- Reviewable:end -->
