### PR TITLE
unbork --samples input

### DIFF
--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -279,8 +279,8 @@ def parse_args() -> argparse.Namespace:
         help='samplesheet to parse sample IDs from'
     )
     parser.add_argument(
-        '--samples', nargs='+',
-        help='list of sample names to run analysis on'
+        '--samples',
+        help='command seperated string of sample names to run analysis on'
     )
     parser.add_argument(
         '--run_info_xml',
@@ -353,6 +353,9 @@ def parse_args() -> argparse.Namespace:
         args.samples = [
             x.replace(' ', '') for x in args.samples.split(',') if x
         ]
+        log.info(
+            f"\nsamples specified to run jobs for: \n\t{args.samples}\n"
+        )
     if args.fastqs:
         args.fastqs = [x.replace(' ', '') for x in args.fastqs.split(',') if x]
 


### PR DESCRIPTION
Fix for being able to use `--samples` to provide a comma separated string of samples on which to run jobs, useful for specifying a normal sample and control when running test jobs

Fixes #66 

Example of fix in job logs:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/b9d7dabb-dc0d-4d01-8fc4-0d400cc2f17b)
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/57e02ace-c1dd-40c0-ae32-a2930a321ed5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/75)
<!-- Reviewable:end -->
