### PR TITLE
Fix ze bug

### DIFF
--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -145,7 +145,7 @@ def match_samples_to_assays(configs, all_samples, testing, mismatch) -> dict:
             # select the config key with for the corresponding value found
             # to be the highest
             highest_ver_config = list(sample_to_assay_configs)[
-                list(sample_to_assay_configs.values).index(highest_ver_config)]
+                list(sample_to_assay_configs.values()).index(highest_ver_config)]
 
             assay_to_samples[highest_ver_config].append(sample)
         else:

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -137,9 +137,15 @@ def match_samples_to_assays(configs, all_samples, testing, mismatch) -> dict:
                 sample_to_assay_configs[code] = configs[code]['version']
 
         if sample_to_assay_configs:
-            # found at least one config to match to sample
+            # found at least one config to match to sample, select
+            # one with the highest version
             highest_ver_config = max(
-                sample_to_assay_configs, key=parseVersion)
+                sample_to_assay_configs.values(), key=parseVersion)
+            
+            # select the config key with for the corresponding value found
+            # to be the highest
+            highest_ver_config = list(sample_to_assay_configs)[
+                list(sample_to_assay_configs.values).index(highest_ver_config)]
 
             assay_to_samples[highest_ver_config].append(sample)
         else:

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -144,10 +144,10 @@ def match_samples_to_assays(configs, all_samples, testing, mismatch) -> dict:
             
             # select the config key with for the corresponding value found
             # to be the highest
-            highest_ver_config = list(sample_to_assay_configs)[
+            latest_config_key = list(sample_to_assay_configs)[
                 list(sample_to_assay_configs.values()).index(highest_ver_config)]
 
-            assay_to_samples[highest_ver_config].append(sample)
+            assay_to_samples[latest_config_key].append(sample)
         else:
             # no match found, just log this as an AssertionError will be raised
             # below for all samples that don't have a match

--- a/resources/home/dnanexus/run_workflows/tests/test_run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_run_workflows.py
@@ -115,7 +115,31 @@ class TestMatchSamplesToAssays():
         assert list(matches.keys()) == ['EGG2|LAB123-3'], (
             "Wrong version of config file selected when matching to samples"
         )
+    
+    def test_select_highest_version_w_lower_code(self):
+        """
+        Test when matching samples to assay configs that the highest version
+        is kept when the assay codes might be 'smaller'
 
+        Test added to check for fix for the following issue:
+            https://github.com/eastgenomics/eggd_conductor/issues/80
+        """
+        configs = {
+            'EGG2|456': {'assay_code': 'EGG2|456', 'version': '1.1.0'},
+            'EGG2|123': {'assay_code': 'EGG2|123', 'version': '1.2.0'}
+        }
+
+        matches = match_samples_to_assays(
+            configs=configs,
+            all_samples=self.single_assay_sample_list,
+            testing=False,
+            mismatch=0
+        )           
+           
+        assert list(matches.keys()) == ['EGG2|123'], (
+            "Wrong version of config file selected when matching to samples"
+        )
+        
 
     def test_mismatch_set_zero(self):
         """


### PR DESCRIPTION
Fix bug in sample matching to assay configs where previously was matching on the code and not version, this is switched to correctly select from the version from the values, then select the corresponding assay code for the given version

Added a bonus unit test to check its now working as expected

Fixes [#80 a real life bug](https://github.com/eastgenomics/eggd_conductor/issues/80)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/81)
<!-- Reviewable:end -->
