### PR TITLE
v1.3.0 dynamic instance selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,6 @@ Examples of instance type setting for a **workflow** using Illumina flowcell ID 
 }
 ```
 
-The above may also be used 
-
 ### Structuring the inputs dictionary
 
 The inputs dict may be given several inputs that act as placeholders to be parsed by the script at runtime. Each key : value pair should be given as the app/stage input as the key, and the placeholder as the value. The key MUST match the input given in the specified workflow /apps available inputs (i.e. in `dxapp.json` for apps, `stage-id.input` for workflows). These are all prefixed with `INPUT-` to be identifiable.

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -23,7 +23,7 @@ import pandas as pd
 
 from utils.dx_requests import PPRINT, DXExecute, DXManage
 from utils.manage_dict import ManageDict
-from utils.utils import Jira, Slack, log, time_stamp
+from utils.utils import Jira, Slack, log, select_instance_types, time_stamp
 
 
 def parse_sample_sheet(samplesheet) -> list:
@@ -563,6 +563,11 @@ def main():
         # save name to params to access later to name job
         params['executable_name'] = exe_names[executable]['name']
 
+        # get instance types to use for executable from config for flowcell
+        instance_types = select_instance_types(
+            run_id=args.run_id,
+            instance_types=params.get('instance_types'))
+
         if params['per_sample'] is True:
             # run workflow / app on every sample
             log.info(f'\nCalling {params["executable_name"]} per sample')
@@ -583,7 +588,8 @@ def main():
                     out_folder=parent_out_dir,
                     job_outputs_dict=job_outputs_dict,
                     executable_out_dirs=executable_out_dirs,
-                    fastq_details=fastq_details
+                    fastq_details=fastq_details,
+                    instance_types=instance_types
                 )
                 total_jobs += 1
 
@@ -598,7 +604,8 @@ def main():
                 out_folder=parent_out_dir,
                 job_outputs_dict=job_outputs_dict,
                 executable_out_dirs=executable_out_dirs,
-                fastq_details=fastq_details
+                fastq_details=fastq_details,
+                instance_types=instance_types
             )
             total_jobs += 1
         else:

--- a/resources/home/dnanexus/run_workflows/tests/test_utils.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_utils.py
@@ -117,7 +117,6 @@ class TestSelectInstanceTypes():
             "wrong instances type selected for S2"
         )
     
-        
     def test_select_S4_from_S4(self):
         """
         Test where S4 is in the instance types dict and xxxxxDSxx is not, that
@@ -182,3 +181,23 @@ class TestSelectInstanceTypes():
         assert selected_instance_types == correct_dict, (
             "Wrong instance types selected fro MiSeq K pattern"
         )
+
+    def test_return_string(self):
+        """
+        Test where flowcell value is a string (i.e. for an app and not
+        workflow stages)
+        """
+        instance_types = {
+            "S1": "mem2_ssd1_v2_x16",
+            "S2": "mem2_ssd1_v2_x48",
+            "S4": "mem2_ssd1_v2_x96"
+        }
+
+        selected_instance = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYDRXY",
+            instance_types=instance_types)
+        
+        assert selected_instance == "mem2_ssd1_v2_x16", (
+            "Wrong instance type returned where return type should be a string"
+        )
+

--- a/resources/home/dnanexus/run_workflows/tests/test_utils.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_utils.py
@@ -1,0 +1,184 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '../../')
+))
+
+from utils.utils import select_instance_types
+
+
+class TestSelectInstanceTypes():
+    instance_types = {
+        "*": {
+            "default_instances": ""
+        },
+        "S1": {
+            "S1_instances_from_S1": ""
+        },
+        "S2": {
+            "S2_instances_from_S2": ""
+        },
+        "S4": {
+            "S4_instances_from_S4": ""
+        },
+        "xxxxxDRxx": {
+            "SP_S1_instances_from_DR_pattern": ""
+        },
+        "xxxxxDMxx": {
+            "S2_instances_from_DM_pattern": ""
+        },
+        "xxxxxDSxx": {
+            "S4_instances_from_DS_pattern": ""
+        },
+        "Kxxxx": {
+            "MiSeq_instances_from_K_pattern": ""
+        }
+    }
+
+    def test_select_S1(self):
+        """
+        Tests that S1 instances can be correctly selected from an S1 flowcell
+        ID pattern when the xxxxxDMxx is defined in the instance type dict
+        """
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYDRXY",
+            instance_types=self.instance_types)
+        
+        correct_dict = {"SP_S1_instances_from_DR_pattern": ""}
+
+        assert selected_instance_types == correct_dict, (
+            "wrong instances type selected for xxxxxDRxx flowcell"
+        )
+
+    def test_select_S2(self):
+        """
+        Tests that S2 instances can be correctly selected from an S2 flowcell
+        ID pattern where defined in instance type dict as S2
+        """
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYDMXY",
+            instance_types=self.instance_types)
+        
+        correct_dict = {"S2_instances_from_DM_pattern": ""}
+        
+        assert selected_instance_types == correct_dict, (
+            "wrong instances type selected for xxxxxDMxx flowcell"
+        )
+    
+    def test_select_S4(self):
+        """
+        Tests that S4 instances can be correctly selected from an S4 flowcell
+        ID pattern when the xxxxxDSxx is defined in the instance type dict
+        """
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLDSXY",
+            instance_types=self.instance_types)
+        
+        correct_dict = {"S4_instances_from_DS_pattern": ""}
+
+        assert selected_instance_types == correct_dict, (
+            "wrong instances type selected for xxxxxDSxx flowcell"
+        )
+
+    def test_select_S1_from_S1(self):
+        """
+        Test where S1 is in the instance types dict and xxxxxDRxx is not, that
+        the dict for S1 is correctly selected
+        """
+        instances = self.instance_types.copy()
+        instances.pop('xxxxxDRxx')
+
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYDRXY",
+            instance_types=instances)
+        
+        correct_dict = {'S1_instances_from_S1': ''}
+
+        assert selected_instance_types == correct_dict, (
+            "wrong instances type selected for S1"
+        )
+    
+    def test_select_S2_from_S2(self):
+        """
+        Test where S2 is in the instance types dict and xxxxxDMxx is not, that
+        the dict for S2 is correctly selected
+        """
+        instances = self.instance_types.copy()
+        instances.pop('xxxxxDMxx')
+
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYDMXY",
+            instance_types=instances)
+        
+        correct_dict = {'S2_instances_from_S2': ''}
+
+        assert selected_instance_types == correct_dict, (
+            "wrong instances type selected for S2"
+        )
+    
+        
+    def test_select_S4_from_S4(self):
+        """
+        Test where S4 is in the instance types dict and xxxxxDSxx is not, that
+        the dict for S4 is correctly selected
+        """
+        instances = self.instance_types.copy()
+        instances.pop('xxxxxDSxx')
+
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYDSXY",
+            instance_types=instances)
+        
+        correct_dict = {'S4_instances_from_S4': ''}
+
+        assert selected_instance_types == correct_dict, (
+            "wrong instances type selected for S4"
+        )
+    
+    def test_default_instance_set_used(self):
+        """
+        Test that when the flowcell ID matches none of the given patterns
+        in the defined instance type dict, the default set is used ("*")
+        """
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYAAAXY",
+            instance_types=self.instance_types)
+        
+        correct_dict = {"default_instances": ""}
+
+        assert selected_instance_types == correct_dict, (
+            "Incorrect default instances used"
+        )
+    
+    def test_return_none_with_no_default(self):
+        """
+        Test where the flowcell ID matches none of the given pattern and
+        no default is provided, that None is returned which will cause
+        dxpy to just use the defaults set by the app / workflow
+        """
+        instances = self.instance_types.copy()
+        instances.pop("*")
+
+        selected_instance_types = select_instance_types(
+            run_id="230324_A01295_0171_BHFFLYAAAXY",
+            instance_types=instances)
+        
+        assert selected_instance_types == None, (
+            "None not returned for no match"
+        )
+    
+    def test_miseq_pattern(self):
+        """
+        Test where flowcell ID is for MiSeq run and Kxxxx pattern is
+        provided in the instance types it matches
+        """
+        selected_instance_types = select_instance_types(
+            run_id="230201_M03595_0015_000000000-KRW44",
+            instance_types=self.instance_types)
+        
+        correct_dict = {"MiSeq_instances_from_K_pattern": ""}
+
+        assert selected_instance_types == correct_dict, (
+            "Wrong instance types selected fro MiSeq K pattern"
+        )

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -88,6 +88,8 @@ class DXExecute():
             instance_type = select_instance_types(
                 run_id=self.args.run_id,
                 instance_types=instance_type)
+        
+        log.info(f"Instance type selected for demultiplexing: {instance_type}")
 
         additional_args = config.get('additional_args')
 

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -14,7 +14,7 @@ import re
 import dxpy as dx
 
 from utils.manage_dict import ManageDict
-from utils.utils import Slack, log, time_stamp
+from utils.utils import Slack, log,select_instance_types, time_stamp
 
 
 PPRINT = PrettyPrinter(indent=1).pprint
@@ -82,6 +82,13 @@ class DXExecute():
         # instance type and additional args may be specified in assay config
         # for runing demultiplexing, get them if present
         instance_type = config.get('instance_type')
+        if isinstance(instance_type, dict):
+            # instance type defined in config is a mapping for multiple
+            # flowcells, select appropriate one for current flowcell
+            instance_type = select_instance_types(
+                run_id=self.args.run_id,
+                instance_types=instance_type)
+
         additional_args = config.get('additional_args')
 
         inputs = {
@@ -281,7 +288,7 @@ class DXExecute():
                 depends_on=prev_jobs,
                 name=job_name,
                 extra_args=extra_args,
-                instance_types=instance_types
+                stage_instance_types=instance_types
             )
         elif 'app-' in executable:
             job_handle = dx.bindings.dxapp.DXApp(dxid=executable).run(

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -232,7 +232,7 @@ class DXExecute():
 
     def call_dx_run(
         self, executable, job_name, input_dict,
-        output_dict, prev_jobs, extra_args) -> str:
+        output_dict, prev_jobs, extra_args, instance_types) -> str:
         """
         Call workflow / app with populated input and output dicts
 
@@ -254,6 +254,8 @@ class DXExecute():
         extra_args : dict
             mapping of any additional arguments to pass to underlying dx
             API call, parsed from extra_args field in config file
+        instance_types : dict
+            mapping of instances to use for apps 
 
         Returns
         -------
@@ -278,7 +280,8 @@ class DXExecute():
                 rerun_stages=['*'],
                 depends_on=prev_jobs,
                 name=job_name,
-                extra_args=extra_args
+                extra_args=extra_args,
+                instance_types=instance_types
             )
         elif 'app-' in executable:
             job_handle = dx.bindings.dxapp.DXApp(dxid=executable).run(
@@ -288,7 +291,8 @@ class DXExecute():
                 ignore_reuse=True,
                 depends_on=prev_jobs,
                 name=job_name,
-                extra_args=extra_args
+                extra_args=extra_args,
+                instance_types=instance_types
             )
         elif 'applet-' in executable:
             job_handle = dx.bindings.dxapplet.DXApplet(dxid=executable).run(
@@ -298,7 +302,8 @@ class DXExecute():
                 ignore_reuse=True,
                 depends_on=prev_jobs,
                 name=job_name,
-                extra_args=extra_args
+                extra_args=extra_args,
+                instance_types=instance_types
             )
         else:
             # doesn't appear to be valid workflow or app
@@ -328,7 +333,8 @@ class DXExecute():
 
     def call_per_sample(
         self, executable, exe_names, input_classes, params, sample, config,
-        out_folder, job_outputs_dict, executable_out_dirs, fastq_details) -> dict:
+        out_folder, job_outputs_dict, executable_out_dirs, fastq_details,
+        instance_types) -> dict:
         """
         Populate input and output dicts for given workflow and sample, then
         call to dx to start job. Job id is returned and stored in output dict
@@ -358,6 +364,8 @@ class DXExecute():
             analysis_1 : /path/to/output)
         fastq_details : list of tuples
             list with tuple per fastq containing (DNAnexus file id, filename)
+        instance_types : dict
+            mapping of instances to use for apps 
 
         Returns
         -------
@@ -457,7 +465,8 @@ class DXExecute():
             input_dict=input_dict,
             output_dict=output_dict,
             prev_jobs=dependent_jobs,
-            extra_args=extra_args
+            extra_args=extra_args,
+            instance_types=instance_types
         )
 
         if sample not in job_outputs_dict.keys():
@@ -472,7 +481,8 @@ class DXExecute():
 
     def call_per_run(
         self, executable, exe_names, input_classes, params, config,
-        out_folder, job_outputs_dict, executable_out_dirs, fastq_details) -> dict:
+        out_folder, job_outputs_dict, executable_out_dirs, fastq_details,
+        instance_types) -> dict:
         """
         Populates input and output dicts from config for given workflow,
         returns dx job id and stores in dict to map workflow -> dx job id.
@@ -499,6 +509,8 @@ class DXExecute():
             analysis_1 : /path/to/output)
         fastq_details : list of tuples
             list with tuple per fastq containing (DNAnexus file id, filename)
+        instance_types : dict
+            mapping of instances to use for apps 
 
         Returns
         -------
@@ -574,7 +586,8 @@ class DXExecute():
             input_dict=input_dict,
             output_dict=output_dict,
             prev_jobs=dependent_jobs,
-            extra_args=extra_args
+            extra_args=extra_args,
+            instance_types=instance_types
         )
 
         # map workflow id to created dx job id

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -299,7 +299,7 @@ class DXExecute():
                 depends_on=prev_jobs,
                 name=job_name,
                 extra_args=extra_args,
-                instance_types=instance_types
+                instance_type=instance_types
             )
         elif 'applet-' in executable:
             job_handle = dx.bindings.dxapplet.DXApplet(dxid=executable).run(
@@ -310,7 +310,7 @@ class DXExecute():
                 depends_on=prev_jobs,
                 name=job_name,
                 extra_args=extra_args,
-                instance_types=instance_types
+                instance_type=instance_types
             )
         else:
             # doesn't appear to be valid workflow or app

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -388,9 +388,14 @@ def select_instance_types(run_id, instance_types) -> dict:
         single instance type is defined, or dict if it is a mapping (i.e for
         multiple stages of a workflow)
     """
+    log.info('Selecting instance types from assay config file')
     if not instance_types:
         # empty dict provided => no user defined instances in config
         return None
+    
+    if isinstance(instance_types, str):
+        # instance types is string => single instance type
+        return instance_types
  
     # mapping of flowcell ID patterns for NovaSeq flowcells from:
     # https://knowledge.illumina.com/instrumentation/general/instrumentation-general-reference_material-list/000005589

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -383,8 +383,10 @@ def select_instance_types(run_id, instance_types) -> dict:
 
     Returns
     -------
-    dict
-        instance types to use for given flowcell
+    dict | str
+        instance types to use for given flowcell, type will be a string if a
+        single instance type is defined, or dict if it is a mapping (i.e for
+        multiple stages of a workflow)
     """
     if not instance_types:
         # empty dict provided => no user defined instances in config


### PR DESCRIPTION
Update to allow for controlling instance types set for jobs dependent upon flowcell used for sequencing, this allows for dynamically scaling up to S2/S4 flowcells where the default instances set for apps/workflows may fail due to lack of compute resources. This has also been added for demultiplexing, which is set via `demultiplex_config` in the top section of the config files.

Identification of flowcell done via last field of run ID according to: https://knowledge.illumina.com/instrumentation/general/instrumentation-general-reference_material-list/000005589

Config accepts either the above patterns, or one of `S1`, `S2` or `S4` which are mapped back to the above patterns.

Main functionality added in `utils.select_instance_types()`, with unit tests added in `test_utils.py`.

Test config file with minimal instance types defined: `file-GVvv2y04ZPKGq63k1Kj4XYf0

Minimal example of instances set in the above config file:
```
"instance_types": {
                "*": {
                    "stage-sentieon_bwa": "mem1_ssd2_v2_x2"
                },
                "S1": {
                    "stage-sentieon_bwa": "mem1_ssd1_v2_x2"
                },
                "S2": {
                    "stage-sentieon_bwa": "mem1_ssd1_v2_x4"
                },
                "xxxxxDRxx": {
                    "stage-sentieon_bwa": "mem1_ssd1_v2_x8"
                }
            }
```

Demultiplexing instances set:
```
"demultiplex_config": {
        "instance_type": {
            "S1": "mem2_ssd1_v2_x32",
            "S2": "mem2_ssd1_v2_x48"
        }
    }
````

---

Closes #64 #78 

**Test for an S1 flowcell (`xxxxxDRxx` pattern)**

https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvqbfQ4ZPK636gK3zgbZ7F7
From logs: 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/ae0d6982-75d9-4795-bffa-0735f4d78a5c)

bwa_mem instance type set from config:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/b3e144b4-81c7-4d85-8bef-1729aff3c723)

---

**Test for an S2 flowcell (`xxxxxDMxx` pattern)**
https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvqp8j4ZPK1q0Q6vqZZ0ZBv

bwa_mem instance type set from config 
https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvqqQ84ZPK3j79pjPYQ0572
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/4fa88edb-59ee-417a-a4c5-3244a4372331)

---

** Test for a flowcell that doesn't match any set and use default `*` types **
https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvv3j84ZPKG3XgGZ1ZVbjk3

bwa_mem instance type set from config: https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvv4784ZPKKVppkQB7vZvVb
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/d2846f0a-6533-4baa-9956-b907a909aa7e)


---

**Test for demultiplexing an S1 flowcell**
https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvv6FQ4ZPKG3XgGZ1ZVbjvf

From logs: 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/d48eb5a5-0703-4172-a987-2b1f80031d74)


bcl2fastq job: https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvv7b84ZPKKVppkQB7vZvb6

demultiplexing instance type set:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/1a8134fb-ab7b-4f71-b0fe-3e0e2a61a7af)


---

**Test for demultiplexing an S2 flowcell**
https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvv6b84ZPK1JGB3B4FX9pB0

From logs:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/b163a262-4d50-42f6-a767-e4e6a87d30ef)


bcl2fastq job: https://platform.dnanexus.com/projects/GVvFxZ04ZPKG3XgGZ1ZVZQY2/monitor/job/GVvv83Q4ZPKGjy6Vz2g2KjFz


demultiplexing instance type set:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/caa6c74f-c70f-4d03-918e-c550b301bacc)

