### PR TITLE
v1.3.0 add user

### DIFF
--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -249,8 +249,12 @@ main () {
         _parse_fastqs
     fi
 
+    # get user who launched job to add to Slack notification
+    user=$(dx describe --json "$PARENT_JOB_ID" | jq -r '.launchedBy' | sed 's/user-//')
+
     # send a message to logs so we know something is starting
     message=":gear: eggd_conductor: Automated analysis beginning to process *${RUN_ID}*%0A"
+    message+="Launched by: ${user}%0A"
     message+="${conductor_job_url}"
     _slack_notify "$message" "$SLACK_LOG_CHANNEL"
 


### PR DESCRIPTION
Adds `launchedBy` user to initial start notification

Closes #79 

![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/c81efb22-7842-436a-bbd3-f4a68368d0e0)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/84)
<!-- Reviewable:end -->
