### PR TITLE
v1.4.0 - set destination

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -152,7 +152,7 @@
     {
       "name": "assay_config_file_id",
       "label": "assay config file ID",
-      "class": "file",
+      "class": "string",
       "optional": true,
       "help": "file ID of assay config file used for analysis (note this file is not output by the app, it is just the one used for analysis)"
     }

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -413,7 +413,7 @@ def main():
         # is to make it easier to audit what configs were used for analysis
         subprocess.run(
             "dx-jobutil-add-output assay_config_file_id "
-            f"{config_data[assay_code]['file_id']} --class=file",
+            f"{config_data[assay_code]['file_id']} --class=string",
             shell=True, check=False
         )
 

--- a/resources/home/dnanexus/run_workflows/utils/dx_log.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_log.py
@@ -20,6 +20,6 @@ def dx_log() -> logging.Logger:
         logger.addHandler(DXLogHandler())
 
     logger.propagate = False
-    logger.setLevel(logging.DEBUG)
+    logger.setLevel(logging.INFO)
 
     return logger

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -264,7 +264,7 @@ class DXExecute():
             mapping of any additional arguments to pass to underlying dx
             API call, parsed from extra_args field in config file
         instance_types : dict
-            mapping of instances to use for apps 
+            mapping of instances to use for apps
 
         Returns
         -------
@@ -280,11 +280,17 @@ class DXExecute():
         log.info(PPRINT(input_dict))
 
         if 'workflow-' in executable:
+            # get common top level of each apps output destination
+            # to set as output of workflow for consitency of viewing
+            # in the browser
+            parent_path = os.path.commonprefix(list(output_dict.values()))
+
             job_handle = dx.bindings.dxworkflow.DXWorkflow(
                 dxid=executable,
                 project=self.args.dx_project_id
             ).run(
                 workflow_input=input_dict,
+                folder=parent_path,
                 stage_folders=output_dict,
                 rerun_stages=['*'],
                 depends_on=prev_jobs,

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -666,10 +666,15 @@ class ManageDict():
                 app_name = exe_names[executable]['stages'][stage]
                 dir = dir.replace("STAGE-NAME", app_name)
 
+            destination = os.environ.get('DESTINATION')
+            if destination and destination != 'null':
+                # add app destination as top level output if given
+                dir = f"/{destination}/{dir}"
+
             # ensure we haven't accidentally got double slashes in path
             dir = dir.replace('//', '/')
 
-            # ensure we don't end up with double /ouput if given in config and
+            # ensure we don't end up with double /output if given in config and
             # using OUT-FOLDER
             dir = dir.replace('output/output', 'output')
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -667,7 +667,7 @@ class ManageDict():
                 dir = dir.replace("STAGE-NAME", app_name)
 
             destination = os.environ.get('DESTINATION')
-            if destination and destination != 'null':
+            if destination:
                 # add app destination as top level output if given
                 dir = f"/{destination}/{dir}"
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -220,8 +220,6 @@ main () {
     mark-section "setting up"
     _set_environment
 
-    printenv
-
     python3 -m pip install -q --no-index --no-deps  packages/*
 
     # link to current running job

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -19,6 +19,10 @@ _set_environment () {
     export PROJECT_ID=$DX_PROJECT_CONTEXT_ID
     export PARENT_JOB_ID=$DX_JOB_ID
 
+    # get the destination path (if set) to conductor to use
+    # as top level of launched jobs output
+    export DESTINATION=$(jq -r '.folder' dnanexus-job.json)
+
     # clear all set env variables to allow logging in and access to other projects
     unset DX_WORKSPACE_ID
     dx cd $DX_PROJECT_CONTEXT_ID:
@@ -216,6 +220,8 @@ main () {
     mark-section "setting up"
     _set_environment
 
+    printenv
+
     python3 -m pip install -q --no-index --no-deps  packages/*
 
     # link to current running job
@@ -269,7 +275,7 @@ main () {
 
         # add file ID of config as output field to easily audit what configs used for analyses
         ASSAY_CONFIG_ID=$(grep -oE 'file-[A-Za-z0-9]+' <<< "$ASSAY_CONFIG")
-        dx-jobutil-add-output assay_config_file_id "$ASSAY_CONFIG_ID" --class=file
+        dx-jobutil-add-output assay_config_file_id "$ASSAY_CONFIG_ID" --class=string
     fi
     if [[ "$CREATE_PROJECT" == 'false' && -z "$DX_PROJECT" ]]; then
         # default behaviour to not create analysis project and use same as


### PR DESCRIPTION
- pass through output provided to the app with `--destination` if specified to be the top level output of launched jobs
  - Fixes #89 
- for workflows, set the common path of constituent apps to be the folder output (functionally doesn't change anything as `stage_folders` controls the app output, but now displays better in web UI)
  - Fixes #71 
- make the assay config file used just be a string output instead of file

- example job with destination set: https://platform.dnanexus.com/panx/projects/GbvyYZj4zQV7xXvj49XBXF4V/monitor/job/Gbvzj6j4zQV6Z22fv474vp3p
  - launched workflow: https://platform.dnanexus.com/panx/projects/GbvyYZj4zQV7xXvj49XBXF4V/monitor/analysis/GbvzkqQ4zQV4PxF97V6Y2b4j
  
- example job without destination set: https://platform.dnanexus.com/panx/projects/GbvyYZj4zQV7xXvj49XBXF4V/monitor/job/Gbvzpyj4zQV2b2j4KGfJJj0F
  - launched workflow: https://platform.dnanexus.com/panx/projects/GbvyYZj4zQV7xXvj49XBXF4V/monitor/analysis/GbvzqV04zQVJ22QyyV959jX1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/91)
<!-- Reviewable:end -->
