### PR TITLE
v1.4.0 - handle TSO500 reports workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pipenv codecov
-        pip install -r requirements.txt
+        pip install -q --no-index --no-deps  resources/home/dnanexus/packages/*
         pipenv install --dev
     # - name: Build bcftools
     #   run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,37 @@
+name: pytest
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv codecov
+        pip install -r requirements.txt
+        pipenv install --dev
+    # - name: Build bcftools
+    #   run: |
+    #     wget https://github.com/samtools/bcftools/releases/download/1.18/bcftools-1.18.tar.bz2
+    #     tar xf bcftools-1.18.tar.bz2
+    #     cd bcftools-1.18
+    #     ./configure --prefix=/usr/local/
+    #     sudo make
+    #     sudo make install
+    # - name: Build htslib
+    #   run: |
+    #     wget https://github.com/samtools/htslib/releases/download/1.18/htslib-1.18.tar.bz2
+    #     tar xf htslib-1.18.tar.bz2
+    #     cd htslib-1.18
+    #     ./configure --prefix=/usr/local/
+    #     sudo make
+    #     sudo make install
+    - name: Test with pytest
+      run: |
+        pytest -vv --cov resources/home/dnanexus/run_workflows/

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pipenv codecov
-        pip install -q --no-index --no-deps  resources/home/dnanexus/packages/*
+        pip install -q --no-index resources/home/dnanexus/packages/*
         pipenv install --dev
     # - name: Build bcftools
     #   run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install pipenv codecov
-        pip install -q --no-index resources/home/dnanexus/packages/*
+        pip install -r requirements.txt
         pipenv install --dev
     # - name: Build bcftools
     #   run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ flatten_json==0.1.13
 packaging==20.3
 pandas==1.4.1
 pytest==7.0.1
-Requests==2.31.0
+Requests==2.*
 urllib3==1.25.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+dxpy==0.318.1
+flatten_json==0.1.13
+packaging==20.3
+pandas==1.4.1
+pytest==7.0.1
+Requests==2.31.0
+urllib3==1.25.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,11 @@ flatten_json==0.1.13
 packaging==20.3
 pandas==1.4.1
 pytest==7.0.1
+pytest-cov==4.0.0
+pytest-html==4.1.0
+pytest-metadata==3.0.0
+pytest-mock==3.11.1
+pytest-subtests==0.11.0
+python-dateutil==2.8.2
 Requests==2.*
 urllib3==1.25.8

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -569,6 +569,12 @@ def main():
         # save name to params to access later to name job
         params['executable_name'] = exe_names[executable]['name']
 
+        if params['executable_name'] == 'eggd_tso500':
+            print("SKIPPING")
+            job_outputs_dict['analysis_1'] = 'job-Gb5qGBj4QJYZkKPX315y0Yv0'
+            continue
+            # record-GZvVyk04X7kz5kPB5QF6V2qx
+
         # get instance types to use for executable from config for flowcell
         instance_types = select_instance_types(
             run_id=args.run_id,

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -569,12 +569,6 @@ def main():
         # save name to params to access later to name job
         params['executable_name'] = exe_names[executable]['name']
 
-        if params['executable_name'] == 'eggd_tso500':
-            print("SKIPPING")
-            job_outputs_dict['analysis_1'] = 'job-Gb5qGBj4QJYZkKPX315y0Yv0'
-            continue
-            # record-GZvVyk04X7kz5kPB5QF6V2qx
-
         # get instance types to use for executable from config for flowcell
         instance_types = select_instance_types(
             run_id=args.run_id,

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -605,21 +605,6 @@ def main():
                 )
                 total_jobs += 1
 
-            if params.get('hold'):
-                # specified to hold => wait for all sample jobs to complete
-                # job_outputs_dict for per sample jobs structured as:
-                # {'sample1': {'analysis_1': 'job-xxx'}...}
-                job_ids = [x.get(params['analysis']) for x in job_outputs_dict.values()]
-                log.info(
-                    f'Holding conductor until {len(job_ids)} '
-                    f'{params["executable_name"]} job(s) complete...'
-                )
-                for job in job_ids:
-                    if job.startswith('job-'):
-                        dx.DXJob(dxid=job).wait_on_done()
-                    else:
-                        dx.DXAnalysis(dxid=job).wait_on_done()
-
         elif params['per_sample'] is False:
             # run workflow / app on all samples at once
             job_outputs_dict = dx_execute.call_per_run(
@@ -636,15 +621,6 @@ def main():
             )
             total_jobs += 1
 
-            if params.get('hold'):
-                print(f"Holding conductor until {params['name']} completes...")
-                executable_id = job_outputs_dict[params['analysis']]
-
-                if executable_id.startswith('job-'):
-                    dx.DXJob(dxid=executable_id).wait_on_done()
-                else:
-                    dx.DXAnalysis(dxid=executable_id).wait_on_done()
-
         else:
             # per_sample is not True or False, exit
             raise ValueError(
@@ -657,6 +633,14 @@ def main():
             f'launched successfully!\n\n'
         )
 
+        if params.get('hold'):
+            # specified to hold => wait for all jobs to complete
+            DXManage().hold_on_wait(
+                analysis=params['analysis'],
+                analysis_name=params['executable_name'],
+                all_job_ids=job_outputs_dict
+            )
+
     with open('total_jobs.log', 'w') as fh:
         fh.write(str(total_jobs))
 
@@ -666,7 +650,7 @@ def main():
     Jira().add_comment(
         run_id=args.run_id,
         comment=(
-            "All jobs sucessfully launched by eggd_conductor. "
+            "All jobs successfully launched by eggd_conductor. "
             "\nAnalysis project: "
         ),
         url=(

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -428,13 +428,13 @@ def main():
         args.dx_project_id = DXManage(args).get_or_create_dx_project(config)
 
     # write analysis project to file to pick up at end to send Slack message
-    output_project = dx.bindings.dxproject.DXProject(
-        dxid=args.dx_project_id).describe().get('name')
     with open('analysis_project.log', 'w') as fh:
         fh.write(
             f'{args.dx_project_id} {args.assay_name} {config.get("version")}\n'
         )
 
+    output_project = dx.bindings.dxproject.DXProject(
+        dxid=args.dx_project_id).describe().get('name')
     args.dx_project_name = output_project
 
     print(

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -635,7 +635,7 @@ def main():
 
         if params.get('hold'):
             # specified to hold => wait for all jobs to complete
-            DXManage().hold_on_wait(
+            DXManage().wait_on_done(
                 analysis=params['analysis'],
                 analysis_name=params['executable_name'],
                 all_job_ids=job_outputs_dict

--- a/resources/home/dnanexus/run_workflows/tests/__init__.py
+++ b/resources/home/dnanexus/run_workflows/tests/__init__.py
@@ -1,3 +1,0 @@
-from pathlib import Path
-
-TEST_DATA_DIR = f"{Path(__file__).parent.resolve()}/data"

--- a/resources/home/dnanexus/run_workflows/tests/settings.py
+++ b/resources/home/dnanexus/run_workflows/tests/settings.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+TEST_DATA_DIR = f"{Path(__file__).parent.resolve()}/data"

--- a/resources/home/dnanexus/run_workflows/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_dx_requests.py
@@ -1,7 +1,11 @@
 from copy import deepcopy
 import os
-import pytest
+import unittest
+from unittest.mock import patch
 import sys
+
+import pytest
+
 sys.path.append(os.path.abspath(
     os.path.join(os.path.realpath(__file__), '../../')
 ))
@@ -53,13 +57,13 @@ class TestFilterHighestConfigVersion():
         for each assay code.
 
         Unique assay codes present between all configs:
-            EGG2, EGG5, LAB123, LAB456 
+            EGG2, EGG5, LAB123, LAB456
 
         We expect to return the following:
             - EGG2|LAB123 -> 1.2.0
             - LAB123|LAB456 -> 1.3.0
             - EGG5 -> 1.1.0
-        
+
         Rationale of each single code matching:
             - subset of unique individual codes: EGG2, EGG5, LAB123 & LAB456
             - matches for each:
@@ -197,6 +201,83 @@ class TestFilterHighestConfigVersion():
 
         with pytest.raises(AssertionError):
             DXManage.filter_highest_config_version(config_files)
+
+
+class TestDXManageGetJobOutputDetails(unittest.TestCase):
+    """
+    Tests for DXManage.get_job_output_details()
+
+    Function queries the output directory of a given job for output
+    files, then filters these down by the given job ID to ensure
+    they are output from that job. This is to get all the output
+    file details in an efficient manner since dxpy.describe on a
+    job can't return the output file details directly
+
+    Tests will just be to show that only files for the given job
+    are correctly returned
+    """
+    @patch('utils.dx_requests.dx.DXJob')
+    @patch('utils.dx_requests.dx.find_data_objects')
+    def test_only_job_specified_job_files_returned(self, mock_find, mock_job):
+        """
+        Test when a directory has other job output in that only the
+        output from the given job is returned
+        """
+        # minimal return of dx.describe on given job ID
+        mock_job.return_value.describe.return_value = {
+            'id': 'job-xxx',
+            'project': 'project-xxx',
+            'output': [
+                {
+                    'output_field1': [
+                        {'$dnanexus_link': 'file-xxx'}
+                    ]
+                }
+            ]
+        }
+
+        # minimal dx.find_data_objects return with files from multiple jobs
+        mock_find.return_value = [
+            {
+                'id': 'file-xxx',
+                'describe': {
+                    'createdBy': {
+                        'job': 'job-xxx'
+                    }
+                }
+            },
+            {
+                'id': 'file-yyy',
+                'describe': {
+                    'createdBy': {
+                        'job': 'job-yyy'
+                    }
+                }
+            },
+            {
+                'id': 'file-zzz',
+                'describe': {
+                    'createdBy': {
+                        'job': 'job-zzz'
+                    }
+                }
+            }
+        ]
+
+        files, ids = DXManage(None).get_job_output_details('job-xxx')
+
+        with self.subTest():
+            self.assertEqual(files, [mock_find.return_value[0]])
+
+        with self.subTest():
+            correct_ids = [
+                {
+                    'output_field1': [
+                        {'$dnanexus_link': 'file-xxx'}
+                    ]
+                }
+            ]
+            self.assertEqual(ids, correct_ids)
 
 
 

--- a/resources/home/dnanexus/run_workflows/tests/test_dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_dx_requests.py
@@ -267,9 +267,11 @@ class TestDXManageGetJobOutputDetails(unittest.TestCase):
         files, ids = DXManage(None).get_job_output_details('job-xxx')
 
         with self.subTest():
+            # test the describe object for job-xxx returned
             self.assertEqual(files, [mock_find.return_value[0]])
 
         with self.subTest():
+            # test only the IDs from job-xxx objects returned
             correct_ids = [
                 {
                     'output_field1': [
@@ -293,7 +295,7 @@ class TestDXManageWaitOnDone(unittest.TestCase):
     @patch('utils.dx_requests.dx.DXJob')
     def test_job_held(self, mock_job):
         """
-        Test when per run and per jobs are held on completing
+        Test when per run and per sample jobs are held on completing
         """
         # minimal dict mapping launched jobs, per run jobs will be defined
         # in the top level of the dict, and per sample jobs will be stored
@@ -331,7 +333,8 @@ class TestDXManageWaitOnDone(unittest.TestCase):
     @patch('utils.dx_requests.dx.DXAnalysis')
     def test_analysis_held(self, mock_analysis):
         """
-        Test when per run and per jobs are held on completing
+        Test when per run and per sample analyses (i.e. running a workflow)
+        are held on completing
         """
         # minimal dict mapping launched analysis (i.e. workflows), per
         # run analysis will be defined in the top level of the dict, and

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1240,6 +1240,8 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
                 "stage-generate_variant_workbook.additional_files": "eggd_tso500.cvo",
          }
 
+        # minimal example files as would be returned from finding files in
+        # eggd_tso500 directory with dx_requests.DXManage.get_job_output_details()
         self.all_output_files = [
             {'id': 'file-a1', 'describe': {'name': 'sample1_R1.fastq'}},
             {'id': 'file-a2', 'describe': {'name': 'sample1_R2.fastq'}},
@@ -1263,6 +1265,8 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
             {'id': 'file-i1', 'describe': {'name': 'metricsOutput.tsv'}},
         ]
 
+
+        # example mapping of eggd_tso500 output fields -> $dnanexus_links
         self.job_output_ids = {
             'fastqs': [
                 {'$dnanexus_link': 'file-a1'},
@@ -1368,6 +1372,8 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
         Test when a sample is missing a file that an AssertionError is raised
         """
         missing_files = deepcopy(self.all_output_files)
+
+        # remove cvo file for sample 1 from output files
         missing_files = [
             x for x in missing_files if not x.get('id') == 'file-h1'
         ]
@@ -1377,7 +1383,7 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
             'for input eggd_tso500.cvo'
         )
         with pytest.raises(AssertionError, match=expected_error):
-            populated_input_dict = ManageDict().populate_tso500_reports_workflow(
+            ManageDict().populate_tso500_reports_workflow(
                 input_dict=self.reports_workflow_input_dict,
                 sample='sample1',
                 all_output_files=missing_files,
@@ -1396,14 +1402,9 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
         expected_error = 'No metrics output file found from tso500 job'
 
         with pytest.raises(AssertionError, match=expected_error):
-            populated_input_dict = ManageDict().populate_tso500_reports_workflow(
+            ManageDict().populate_tso500_reports_workflow(
                 input_dict=self.reports_workflow_input_dict,
                 sample='sample1',
                 all_output_files=self.all_output_files,
                 job_output_ids=missing_files
             )
-
-
-if __name__ == '__main__':
-
-    pass

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.abspath(
 ))
 
 from utils.manage_dict import PPRINT, ManageDict
-from tests import TEST_DATA_DIR
+from .settings import TEST_DATA_DIR
 
 
 class TestSearchDict():
@@ -512,7 +512,7 @@ class TestAddOtherInputs():
     }
 
     # set samplesheet file ID as env variable as set in eggd_conductor.sh
-    os.environ['SAMPLESHEET'] = (
+    os.environ['SAMPLESHEET_ID'] = (
         "{'$dnanexus_link': 'file-GGxPVxQ4X7kbkFBx7b913b0G'}"
     )
 

--- a/resources/home/dnanexus/run_workflows/tests/test_run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_run_workflows.py
@@ -10,7 +10,7 @@ sys.path.append(os.path.abspath(
     os.path.join(os.path.realpath(__file__), '../../../')
 ))
 
-from tests import TEST_DATA_DIR
+from .settings import TEST_DATA_DIR
 from run_workflows.run_workflows import (
     match_samples_to_assays, parse_run_info_xml, parse_sample_sheet)
 

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -1234,7 +1234,7 @@ class DXManage():
         return all_output_files, job_output_ids
 
 
-    def hold_on_wait(self, analysis, analysis_name, all_job_ids) -> None:
+    def wait_on_done(self, analysis, analysis_name, all_job_ids) -> None:
         """
         Hold eggd_conductor until all job(s) for the given analysis step
         have completed

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -7,15 +7,15 @@ from copy import deepcopy
 from datetime import datetime
 import json
 import os
-from packaging.version import Version, parse
 from pprint import PrettyPrinter
 import re
 from typing import Tuple
 
 import dxpy as dx
+from packaging.version import Version, parse
 
 from utils.manage_dict import ManageDict
-from utils.utils import Slack, log,select_instance_types, time_stamp
+from utils.utils import Slack, log, select_instance_types, time_stamp
 
 
 PPRINT = PrettyPrinter(indent=1).pprint
@@ -23,7 +23,7 @@ PPRINT = PrettyPrinter(indent=1).pprint
 
 class DXExecute():
     """
-    Methods for handling exeuction of apps / worklfows
+    Methods for handling execution of apps / workflows
     """
     def __init__(self, args) -> None:
         self.args = args
@@ -1257,9 +1257,12 @@ class DXManage():
             if isinstance(x, dict)
         ])
 
+        # ensure we don't have any Nones
+        job_ids = [x for x in job_ids if x]
+
         log.info(
             f'Holding conductor until {len(job_ids)} '
-            f'{analysis_name} job(s) complete...'
+            f'{analysis_name} job(s) complete: {", ".join(job_ids)}'
         )
 
         for job in job_ids:

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -416,7 +416,7 @@ class ManageDict():
         if sample:
             # running per sample, assume we only wait on the samples previous
             # job and not all instances of the given executable for all samples
-            job_outputs_dict = job_outputs_dict[sample]
+            job_outputs_dict = job_outputs_dict.get(sample, {})
 
         # check if job depends on previous jobs to hold till complete
         dependent_analyses = params.get("depends_on")

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -270,7 +270,7 @@ class ManageDict():
         args : argparse.Namespace
             namespace object of passed cmd line arguments
         executable_out_dirs : dict
-            dict of analsysis stage to its output dir path, used to pass output of
+            dict of analysis stage to its output dir path, used to pass output of
             an analysis to input of another (i.e. analysis_1 : /path/to/output)
         sample : str, default None
             optional, sample name used to filter list of fastqs

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -952,8 +952,8 @@ class ManageDict():
             # get the actual stage.field from input dict, we will
             # have this something like:
             # inputs: {
-            # "stage-GF22j384b0bpYgYB5fjkk34X.bam": "eggd_tso500.bam",
-            # "stage-GF22j384b0bpYgYB5fjkk34X.index": "eggd_tso500.idx"
+            #   "stage-GF22j384b0bpYgYB5fjkk34X.bam": "eggd_tso500.bam",
+            #   "stage-GF22j384b0bpYgYB5fjkk34X.index": "eggd_tso500.idx"
             # }
             # the value strings are pretty arbitrary bu the main thing is
             # we're not hardcoding the actual stage IDs here in case they

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -5,7 +5,6 @@ dictionaries for passing to dx run.
 
 from copy import deepcopy
 from pprint import PrettyPrinter
-from operator import itemgetter
 import os
 import re
 import sys

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -9,8 +9,13 @@ import re
 import requests
 from requests.adapters import HTTPAdapter
 from requests.auth import HTTPBasicAuth
+import sys
 import traceback
 from urllib3.util import Retry
+
+sys.path.append(os.path.abspath(
+    os.path.join(os.path.realpath(__file__), '../')
+))
 
 from utils.dx_log import dx_log
 
@@ -393,12 +398,12 @@ def select_instance_types(run_id, instance_types) -> dict:
         # empty dict provided => no user defined instances in config
         log.info('No instance types set to use from config')
         return None
-    
+
     if isinstance(instance_types, str):
         # instance types is string => single instance type
         log.info(f"Single instance type set: {instance_types}")
         return instance_types
- 
+
     # mapping of flowcell ID patterns for NovaSeq flowcells from:
     # https://knowledge.illumina.com/instrumentation/general/instrumentation-general-reference_material-list/000005589
     # "SP": "xxxxxDRxx"
@@ -424,7 +429,7 @@ def select_instance_types(run_id, instance_types) -> dict:
             # make x's n or more character regex pattern (e.g. [\d\w]{5,})
             if start_x:
                 start_x = f"[\d\w]{{{len(start_x)},}}"
-            
+
             if end_x:
                 end_x = f"[\d\w]{{{len(end_x)},}}"
 


### PR DESCRIPTION
## Summary
Add in functionality for specifically handling of parsing eggd_tso500/2.0.0 output -> TSO500 reports workflow for automating running all of Helios pipeline

## Changes
- New functions:
  - `DXManage.get_job_output_details()` - used to get full describe output of a given jobs output files
  - `DXManage.wait_on_done()` - refactor of code from `main()` added in #92 to separate function for easier unit testing
  - `ManageDict.populate_tso500_reports_workflow()` - main logic for parsing of eggd_tso500 output into per sample reports workflows
- unit tests added for new functions
- added GitHub action to run unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/93)
<!-- Reviewable:end -->
