### PR TITLE
v1.4.0 - add job_reuse input

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ The following describe default app input behaviour:
 - `MISMATCH_ALLOWANCE` (default: 1): no. of samples allowed to be missing assay code and continue analysis using the assay code of the other samples on the run (i.e. allows for a control sample on the run not named specifically for the assay)
 - `DEMULTIPLEX_JOB_ID` (optional):  use output fastqs of a previous demultiplexing job instead of performing demultiplexing
 - `DEMULTIPLEX_OUT` (optional): path to store demultiplexing output, if not given will default parent of sentinel file. Should be in the format `project:path`
+- `JOB_REUSE` (`string`; optional): JSON formatted string mapping analysis step -> job ID to reuse outputs from instead of running analysis (i.e. '{"analysis_1": "job-xxx"}'). This is currently only implemented for per-run analysis steps.
 
 
 ## Demultiplexing

--- a/dxapp.json
+++ b/dxapp.json
@@ -96,6 +96,13 @@
       "help": "Parsed from samplesheet if not given"
     },
     {
+      "name": "JOB_REUSE",
+      "label": "job reuse",
+      "class": "string",
+      "optional": true,
+      "help": "JSON formatted string mapping analysis step -> job ID to reuse outputs from instead of running analysis (i.e. '{\"analysis_1\": \"job-xxx\"}')"
+    },
+    {
       "name": "MISMATCH_ALLOWANCE",
       "label": "mismatch allowance",
       "class": "int",

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -384,10 +384,12 @@ def parse_args() -> argparse.Namespace:
         # check given JOB_REUSE is valid JSON
         try:
             args.job_reuse = json.loads(args.job_reuse)
-        except json.decoder.JSONDecodeError as exc:
+        except json.decoder.JSONDecodeError:
             raise SyntaxError(
-                '-iJOB_REUSE provided does not appear to be valid JSON format'
-            ).with_traceback(sys.exc_info()[2]) from exc
+                Slack().send(
+                   '`-iJOB_REUSE` provided does not appear to be valid '
+                   f'JSON format: `{args.job_reuse}`'
+            ))
     else:
         args.job_reuse = {}
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -306,6 +306,7 @@ main () {
     if [ "$TESTING" == 'true' ]; then optional_args+="--testing "; fi
     if [ "$TESTING_SAMPLE_LIMIT" ]; then optional_args+="--testing_sample_limit ${TESTING_SAMPLE_LIMIT} "; fi
     if [ "$MISMATCH_ALLOWANCE" ]; then optional_args+="--mismatch_allowance ${MISMATCH_ALLOWANCE} "; fi
+    if [ "$JOB_REUSE" ]; then optional_args+="--job_reuse ${JOB_REUSE} "; fi
 
     echo $optional_args
 


### PR DESCRIPTION
- adds additional optional input `-iJOB_REUSE` to allow for patching in previously run jobs to reuse output from
- main use case for this is for running reports workflows for TSO500 and decoupling this from always having to rerun the eggd_tso500 app

- example job specifying an eggd_tso500 job ID to reuse from: https://platform.dnanexus.com/panx/projects/GfK06Pj412V7Qbfb2zJqPZ8y/monitor/job/GfKXQg0412V9P7Y9KxFxFfKB
  - from above job logs: 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/2dfc2002-1f0f-42fe-8bd6-6d316e29365a)  
  - launched downstream jobs: 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/f9f12850-cebb-4405-a351-6a02e04e35ac)

- example job without reuse specified: https://platform.dnanexus.com/panx/projects/GfK06Pj412V7Qbfb2zJqPZ8y/monitor/job/GfKXbV8412V6KF3VqqxzgBvZ
  - launched job: 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/1d8a240f-0326-44f5-8513-bfaa5d3a3868)

- example of catching error where invalid JSON string provided to `-iJOB_REUSE`: https://platform.dnanexus.com/panx/projects/GfK06Pj412V7Qbfb2zJqPZ8y/monitor/job/GfKY26Q412V64jbfxf8XKz9J
  - error alert sent: 
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/5baf70e1-621c-465a-b3bd-cccd1f5d2b5e)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/95)
<!-- Reviewable:end -->
