### PR TITLE
v1.4.0 - fix tso500 reports launch + fix for #88

### DIFF
--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -469,7 +469,7 @@ class TestAddFastqs(unittest.TestCase):
         with self.subTest():
             self.assertEqual(
                 output['stage-G0qpXy0433Gv75XbPJ3xj8jV.reads_fastqgzs'],
-                 [
+                [
                     {'$dnanexus_link': 'file-xxx2'},
                     {'$dnanexus_link': 'file-xxx1'}
                 ]
@@ -478,7 +478,7 @@ class TestAddFastqs(unittest.TestCase):
         with self.subTest():
             self.assertEqual(
                 output['stage-G0qpXy0433Gv75XbPJ3xj8jV.reads2_fastqgzs'],
-                 [
+                [
                     {'$dnanexus_link': 'file-yyy2'},
                     {'$dnanexus_link': 'file-yyy1'}
                 ]

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -214,7 +214,7 @@ class TestReplaceDict():
         )
 
 
-class TestAddFastqs():
+class TestAddFastqs(unittest.TestCase):
     """
     Tests for adding fastq file IDs to input dict
     """
@@ -358,7 +358,6 @@ class TestAddFastqs():
             "R1 fastqs not correctly added for given sample"
         )
 
-
     def test_adding_per_sample_r2_fastqs(self):
         """
         Test adding fastqs when a sample defined => fastqs should be for just
@@ -437,6 +436,52 @@ class TestAddFastqs():
                 ),
                 fastq_details=self.fastq_details,
                 sample='test-sample'
+            )
+
+    def test_sorting_per_lane_correct(self):
+        """
+        Test that fastqs are sorted and added in the correct order
+        by lane number, ensure we are actually sorting on the filename
+        and not the file ID
+        """
+        fastq_details = [
+            ('file-xxx2',
+            '2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2_S32_L001_R1_001.fastq.gz'),
+            ('file-xxx1',
+            '2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2_S32_L002_R1_001.fastq.gz'),
+            ('file-yyy2',
+            '2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2_S32_L001_R2_001.fastq.gz'),
+            ('file-yyy1',
+            '2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2_S32_L002_R2_001.fastq.gz')
+        ]
+
+        output = ManageDict().add_fastqs(
+            input_dict=deepcopy(
+                self.test_input_dict['workflow-GB6J7qQ433Gkf0ZYGbKfF0x6']["inputs"]
+            ),
+            fastq_details=fastq_details,
+            sample='2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2'
+        )
+
+        # if we were to be sorting on the file ID, we would expect the
+        # respective xxx1 and yyy1 IDs to be returned first, sorting on
+        # file name should give xxx2 and yyy2 first
+        with self.subTest():
+            self.assertEqual(
+                output['stage-G0qpXy0433Gv75XbPJ3xj8jV.reads_fastqgzs'],
+                 [
+                    {'$dnanexus_link': 'file-xxx2'},
+                    {'$dnanexus_link': 'file-xxx1'}
+                ]
+            )
+
+        with self.subTest():
+            self.assertEqual(
+                output['stage-G0qpXy0433Gv75XbPJ3xj8jV.reads2_fastqgzs'],
+                 [
+                    {'$dnanexus_link': 'file-yyy2'},
+                    {'$dnanexus_link': 'file-yyy1'}
+                ]
             )
 
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -189,8 +189,14 @@ class ManageDict():
             sample_fastqs = fastq_details
 
         # fastqs should always be named with R1/2_001
-        r1_fastqs = sorted([x for x in sample_fastqs if 'R1_001.fastq' in x[1]])
-        r2_fastqs = sorted([x for x in sample_fastqs if 'R2_001.fastq' in x[1]])
+        r1_fastqs = sorted(
+            [x for x in sample_fastqs if 'R1_001.fastq' in x[1]],
+            key=lambda x: x[1]
+        )
+        r2_fastqs = sorted(
+            [x for x in sample_fastqs if 'R2_001.fastq' in x[1]],
+            key=lambda x: x[1]
+        )
 
         log.info(f'Found {len(r1_fastqs)} R1 fastqs & {len(r2_fastqs)} R2 fastqs')
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -949,14 +949,26 @@ class ManageDict():
             }.keys())
 
             if not config_stage_input:
-                # this input not present in config file, likely been removed
+                # this input not present in config file, likely been
+                # removed => skip trying to add it
                 continue
 
             config_stage_input = config_stage_input[0]
 
             # get the corresponding eggd_tso500 output files for
-            # the given stage input
-            dx_links = [job_output_ids.get(x) for x in output_fields]
+            # the given stage input, where there are 2 potential files
+            # (i.e. dna_bams and rna_bams) we expect at least one to
+            # be present, and for cvo they should always be present
+            dx_links = [
+                job_output_ids.get(x) for x in output_fields
+                if job_output_ids.get(x)
+            ]
+
+            assert dx_links, Slack().send(
+                "No output files found from eggd_tso500 job from the "
+                f"output fields: {output_fields}"
+            )
+
             file_ids = [
                 id.get('$dnanexus_link') for sublist in dx_links for id in sublist
             ]

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -306,7 +306,7 @@ main () {
     if [ "$TESTING" == 'true' ]; then optional_args+="--testing "; fi
     if [ "$TESTING_SAMPLE_LIMIT" ]; then optional_args+="--testing_sample_limit ${TESTING_SAMPLE_LIMIT} "; fi
     if [ "$MISMATCH_ALLOWANCE" ]; then optional_args+="--mismatch_allowance ${MISMATCH_ALLOWANCE} "; fi
-    if [ "$JOB_REUSE" ]; then optional_args+="--job_reuse ${JOB_REUSE} "; fi
+    if [ "$JOB_REUSE" ]; then optional_args+="--job_reuse ${JOB_REUSE/ /} "; fi
     if [ "$EXCLUDE_SAMPLES" ]; then optional_args+="--exclude_samples ${EXCLUDE_SAMPLES} "; fi
 
     echo $optional_args


### PR DESCRIPTION
- fix for querying TSO500 jobs with a missing output field (i.e. all DNA samples => expected no RNA outputs)
- handle spaces in `-iJOB_REUSE` input
- specify key sorting of fastqs and additional unit test to `TestAddFastqs`
  - fixes #88 

- example launching all DNA samples:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/47dcfe2f-b316-4029-af88-3eec635b240b)

- example of space in `-iJOB_REUSE` input:
![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/7c4d7133-89e4-4705-a0a8-19049b336036)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/99)
<!-- Reviewable:end -->
