### PR TITLE
v1.4.0 - improve slack alert

### DIFF
--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -280,6 +280,12 @@ class DXExecute():
         log.info(f"\nPopulated input dict for: {executable}")
         log.info(PPRINT(input_dict))
 
+        if os.environ.get('TESTING') == 'true':
+            # running in test mode => don't actually want to run jobs =>
+            # make jobs dependent on conductor job finishing so no launched
+            # jobs actually start running
+            prev_jobs.append(os.environ.get('PARENT_JOB_ID'))
+
         if 'workflow-' in executable:
             # get common top level of each apps output destination
             # to set as output of workflow for consitency of viewing

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -56,7 +56,8 @@ class Slack():
             )
         else:
             message = (
-                f":warning: *Error - eggd_conductor*\n\n{message}\n\n"
+                f":warning: *Error - eggd_conductor*\n\nError in processing "
+                f"run *{os.environ.get('RUN_ID')}*\n\n{message}\n\n"
                 f"eggd_conductor job: {conductor_job_url}"
             )
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -105,7 +105,7 @@ _parse_sentinel_file () {
     sentinel_path=$(jq -r '.details.dnanexus_path' <<< "$sentinel_details")
     sentinel_samplesheet=$(jq -r '.details.samplesheet_file_id' <<< "$sentinel_details")
     if [ -z "$RUN_ID" ]; then
-        RUN_ID=$(jq -r '.details.run_id' <<< "$sentinel_details")
+        export RUN_ID=$(jq -r '.details.run_id' <<< "$sentinel_details")
     fi
 
     tags=$(jq -r '.tags | .[]' <<< "$sentinel_details")


### PR DESCRIPTION
- add in run ID to all error Slack alerts
  - fixes #100 
  - ![image](https://github.com/eastgenomics/eggd_conductor/assets/45037268/74ac90b1-5fc8-4522-ad92-c2639f9229b6)

- when running in test mode, make launched jobs dependent on parent eggd_conductor job so they don't actually run before terminating

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/101)
<!-- Reviewable:end -->
