### PR TITLE
v1.4.0 - fix for job reuse on re-run jobs

### DIFF
--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -417,7 +417,7 @@ class DXExecute():
         extra_args = params.get("extra_args", {})
 
         if params['executable_name'].startswith('TSO500_reports_workflow'):
-            # handle specific inputs of eggd_TSO500 -> TSO500 workflow
+            # handle specific inputs of eggd_TSO500 -> TSO500 workflow\
 
             # get the job ID for previous eggd_tso500 job, this _should_ just
             # be analysis_1, but check anyway incase other apps added in future
@@ -427,9 +427,16 @@ class DXExecute():
                 job_outputs_dict[x] for x in job_outputs_dict if x.startswith('analysis_')
             ]
             jobs = {dx.describe(job_id).get('name'): job_id for job_id in jobs}
-            tso500_id = jobs.get('eggd_tso500')
+            tso500_id = [
+                v for k, v in jobs.items if k.startswith('eggd_tso500')
+            ]
 
-            assert tso500_id, "Could not find prior eggd_tso500 job"
+            assert len(tso500_id) == 1, (
+                "Could not correctly find prior eggd_tso500 "
+                f"job, jobs found: {jobs}"
+            )
+
+            tso500_id = tso500_id[0]
 
             # get details of the job to pull files from
             all_output_files, job_output_ids = DXManage(

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -428,7 +428,7 @@ class DXExecute():
             ]
             jobs = {dx.describe(job_id).get('name'): job_id for job_id in jobs}
             tso500_id = [
-                v for k, v in jobs.items if k.startswith('eggd_tso500')
+                v for k, v in jobs.items() if k.startswith('eggd_tso500')
             ]
 
             assert len(tso500_id) == 1, (

--- a/resources/home/dnanexus/run_workflows/utils/dx_requests.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_requests.py
@@ -417,7 +417,7 @@ class DXExecute():
         extra_args = params.get("extra_args", {})
 
         if params['executable_name'].startswith('TSO500_reports_workflow'):
-            # handle specific inputs of eggd_TSO500 -> TSO500 workflow\
+            # handle specific inputs of eggd_TSO500 -> TSO500 workflow
 
             # get the job ID for previous eggd_tso500 job, this _should_ just
             # be analysis_1, but check anyway incase other apps added in future

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -668,7 +668,7 @@ class ManageDict():
         output_dict : dict
             populated dict of output directory paths
         """
-        prettier_print(f"\nPopulating output dict for {executable}, dict before:")
+        prettier_print(f"\nPopulating output dict for {executable}")
 
         for stage, dir in output_dict.items():
             if "OUT-FOLDER" in dir:


### PR DESCRIPTION
- fix for when specifying `-iJOB_REUSE` for a prior run eggd_tso500 job if that job was a clone it broke reusing the job ID
   - if a job is re-run the name will be in the following format when described:
 ```[16:24:03] - {
⠀⠀"eggd_tso500 (re-run)": "job-GgB5qj84xjk46B02JGb4ZjJp",
⠀⠀"multi_fastqc_v1.1.0": "job-GgBJ48j4zQV2QB5PVGvgZX29"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/103)
<!-- Reviewable:end -->
