### PR TITLE
v1.4.0 - fix destination

### DIFF
--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -534,7 +534,9 @@ def main():
 
     # set parent output directory, each app will have sub dir in here
     # use argparse Namespace for laziness to pass to dx_manage functions
-    parent_out_dir = f"/output/{args.assay_name}-{run_time}"
+    parent_out_dir = (
+        f"{os.environ.get('DESTINATION', '')}/output/{args.assay_name}-{run_time}"
+    )
     args.parent_out_dir = parent_out_dir
 
     # get upload tars from sentinel file, abuse argparse Namespace object

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -605,7 +605,7 @@ class TestAddOtherInputs():
         Test for finding INPUT-parent_out_dir and replacing with parent output
         directory from args Namespace object
         """
-        assert self.output['all_analysis_output'] == 'some_assay-220930-1200', (
+        assert self.output['all_analysis_output'] == '/some_assay-220930-1200', (
             'INPUT-parent_out_dir not correctly replaced'
         )
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -305,9 +305,7 @@ class ManageDict():
             prettier_print(f'\nOther inputs found to replace: {other_inputs}')
 
         # removing /output prefix for now to fit to MultiQC
-        if args.parent_out_dir.startswith('/output'):
-            args.parent_out_dir = re.sub(
-                r'^/output', '', args.parent_out_dir)
+        args.parent_out_dir = re.sub(r'^/output', '', args.parent_out_dir)
 
         samplesheet = ""
         if os.environ.get('SAMPLESHEET_ID'):

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -2,9 +2,7 @@
 Functions related to populating and formatting input and output
 dictionaries for passing to dx run.
 """
-
 from copy import deepcopy
-from pprint import PrettyPrinter
 import os
 import re
 import sys
@@ -306,8 +304,10 @@ class ManageDict():
         else:
             prettier_print(f'\nOther inputs found to replace: {other_inputs}')
 
-        # removing /output/ for now to fit to MultiQC
-        args.parent_out_dir = args.parent_out_dir.replace('/output/', '')
+        # removing /output prefix for now to fit to MultiQC
+        if args.parent_out_dir.startswith('/output'):
+            args.parent_out_dir = re.sub(
+                r'^/output', '', args.parent_out_dir)
 
         samplesheet = ""
         if os.environ.get('SAMPLESHEET_ID'):


### PR DESCRIPTION
- fix to add destination (if specified with `--destination`) to the parent output directory passed through to `INPUT-parent_out_dir` (i.e. for MultiQC)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/105)
<!-- Reviewable:end -->
