### PR TITLE
Fix #116

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -537,6 +537,7 @@ def main():
     parent_out_dir = (
         f"{os.environ.get('DESTINATION', '')}/output/{args.assay_name}-{run_time}"
     )
+    parent_out_dir = parent_out_dir.replace('//', '/')
     args.parent_out_dir = parent_out_dir
 
     # get upload tars from sentinel file, abuse argparse Namespace object

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -605,7 +605,7 @@ class TestAddOtherInputs():
         Test for finding INPUT-parent_out_dir and replacing with parent output
         directory from args Namespace object
         """
-        assert self.output['all_analysis_output'] == '/some_assay-220930-1200', (
+        assert self.output['all_analysis_output'] == 'some_assay-220930-1200', (
             'INPUT-parent_out_dir not correctly replaced'
         )
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -305,7 +305,7 @@ class ManageDict():
             prettier_print(f'\nOther inputs found to replace: {other_inputs}')
 
         # removing /output prefix for now to fit to MultiQC
-        args.parent_out_dir = re.sub(r'^/output', '', args.parent_out_dir)
+        args.parent_out_dir = re.sub(r'^/output/', '', args.parent_out_dir)
 
         samplesheet = ""
         if os.environ.get('SAMPLESHEET_ID'):


### PR DESCRIPTION
- fixes #116
  - now correctly handles passing folder to eggd_multiQC as before with no `/output/` prepended  
- example conductor job: https://platform.dnanexus.com/panx/projects/Gjb4Bjj40Zq5KFFJVzzG56j3/monitor/job/Gjb591Q40Zq1J102kPzFKz02
- example launched multiQC job: https://platform.dnanexus.com/panx/projects/Gjb4Bjj40Zq5KFFJVzzG56j3/monitor/job/Gjb5F9040Zq9f7Kvb61JQ19k

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/117)
<!-- Reviewable:end -->
