### PR TITLE
IN-693 v1.5.0 subset samplesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Example top level of config:
     }
     "demultiplex": true,
     "demultiplex_config": {
-        "app_name": "app-eggd_bclconvert",
+        "app_name": "eggd_bclconvert",
         "additional_args": "--strict-mode true",
         "instance_type": "mem1_ssd1_v2_x36"
     }

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ As the config file is a JSON, several fields may be added to enhance readability
 **Optional keys in top level of assay config include**:
 
 - `changelog` (dict): optional recording of changes for each version of config file, useful for quickly identifying what has changed between versions
+- `subset_samplesheet` (str): optional regex pattern against which the list of samples parsed from the samplesheet will be filtered against to control launching per sample apps / workflows (i.e used to exclude samples present that do not match the given pattern)
 - `demultiplex_config` (dict): a set of config values for the demultiplexing job. This may contain the following keys:
   - `app_id` : app- ID of demultiplexing app to use, this will override the one in the app config if specified.
   - `app_name`: app name of demultiplexing app to use, this will override both the ID in the app config and `app_id` above if specified.

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -781,7 +781,7 @@ def main():
             "\nAnalysis project: "
         ),
         url=(
-            "http://platform.dnanexus.com/projects/"
+            "http://platform.dnanexus.com/panx/projects/"
             f"{args.dx_project_id.replace('project-', '')}/monitor/"
         )
     )

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -506,12 +506,12 @@ def main():
             sample_list=sample_list
         )
 
-    if config_data.get('subset_samplesheet'):
+    if config.get('subset_samplesheet'):
         # subset the sample list from the samplesheet against the
         # pattern provided from the config
         sample_list = subset_samplesheet_samples(
             samples=sample_list,
-            subset=config_data.get('subset_samplesheet')
+            subset=config.get('subset_samplesheet')
         )
 
 

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -28,6 +28,7 @@ from utils.utils import (
     Slack,
     prettier_print,
     select_instance_types,
+    subset_samplesheet_samples,
     time_stamp
 )
 
@@ -504,6 +505,15 @@ def main():
             exclude_samples=args.exclude_samples,
             sample_list=sample_list
         )
+
+    if config_data.get('subset_samplesheet'):
+        # subset the sample list from the samplesheet against the
+        # pattern provided from the config
+        sample_list = subset_samplesheet_samples(
+            samples=sample_list,
+            subset=config_data.get('subset_samplesheet')
+        )
+
 
     if not args.assay_name:
         args.assay_name = config.get('assay')

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -534,3 +534,47 @@ def select_instance_types(run_id, instance_types) -> dict:
         )
         return None
 
+
+def subset_samplesheet_samples(samples, subset) -> list:
+    """
+    Subsets the sample list parsed from the samplesheet against the
+    provided regex pattern.
+
+    This is used to limit what is run for per sample jobs that would
+    use all samples from the samplesheet.
+
+    Parameters
+    ----------
+    samples : list
+        list of samples
+    subset : string
+        regex pattern against which to filter
+
+    Returns
+    -------
+    list
+        subset of sample list
+    """
+    printable_samples = '\n\t'.join(samples)
+    print(
+        f"Subsetting {len(samples)} samples from sample sheet, sample list "
+        f"before:\n\t{printable_samples}"
+    )
+
+    # check that a valid pattern has been provided
+    try:
+        re.compile(subset)
+    except re.error:
+        raise re.error('Invalid subset pattern provided')
+
+    samples = [x for x in samples if re.search(subset, x)]
+
+    assert samples, f"No samples left after filtering using pattern {subset}"
+
+    printable_samples = '\n\t'.join(samples)
+    print(
+        f"Retained {len(samples)} after subsetting with {subset}:"
+        f"\n\t{printable_samples}"
+    )
+
+    return samples

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -256,7 +256,7 @@ main () {
     fi
 
     if [[ "$upload_sentinel_record" ]]; then
-        printf "\nParsing sentinel file"
+        printf "\nParsing sentinel file\n"
         _parse_sentinel_file
     else
         # app run manually without sentinel file


### PR DESCRIPTION
## Summary
Changes to handle excluding pancan samples from being processed through TSO500 pipeline where we have mixed assay sequencing runs

## Changes
- add additional function `utils.subset_samplesheet_samples`  
  - takes the list of samples from the samplesheet and a regex pattern defined in the assay config to filter down the sample list, this will exclude samples not matching the pattern from having per sample analyses launched
- add unit tests for the above new function
- bonus new line for `printf` in `eggd_conductor.sh`
- fix example demultiplex config in readme
- add `panx` to final Slack notification URL
  - fixes #112

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/118)
<!-- Reviewable:end -->
