### PR TITLE
Part 21.2: Add restriction when providing fastqs

### DIFF
--- a/resources/home/dnanexus/run_workflows/utils/dx_utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_utils.py
@@ -65,13 +65,14 @@ def get_json_configs() -> dict:
         f"No config files found in given path: {project}:{path}"
     )
 
-    files_ids = "\n\t".join(
+    files_ids = sorted(
         [
             f"{x['describe']['name']} ({x['id']} - "
             f"{x['describe']['archivalState']})"
             for x in files
         ]
     )
+
     prettier_print("\nAssay config files found:")
     prettier_print(files_ids)
 
@@ -206,11 +207,11 @@ def filter_highest_config_version(all_configs) -> dict:
         ]
 
     # add to log record of highest version of each config found
-    usable_configs = "\n\t".join(
-        [
-            f"{k} ({v['version']}): {v['file_id']}"
+    usable_configs = sorted(
+        {
+            f"{k} ({v['version']})": f"{v['file_id']}"
             for k, v in configs_to_use.items()
-        ]
+        }
     )
 
     prettier_print("\nHighest versions of assay configs found to use:")

--- a/resources/home/dnanexus/run_workflows/utils/dx_utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_utils.py
@@ -72,7 +72,8 @@ def get_json_configs() -> dict:
             for x in files
         ]
     )
-    prettier_print(f"\nAssay config files found:\n\t{files_ids}")
+    prettier_print("\nAssay config files found:")
+    prettier_print(files_ids)
 
     all_configs = []
 
@@ -212,10 +213,8 @@ def filter_highest_config_version(all_configs) -> dict:
         ]
     )
 
-    prettier_print(
-        "\nHighest versions of assay configs found to use:"
-        f"\n\t{usable_configs}\n"
-    )
+    prettier_print("\nHighest versions of assay configs found to use:")
+    prettier_print(usable_configs)
 
     return configs_to_use
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -341,7 +341,7 @@ main () {
             # should only be ran if there is an error after starting all the jobs
             # non empty log => jobs to terminate
             echo "Terminating jobs"
-            jobs=$(sed -e "s/,/ /g" all_job_ids.log | xargs)
+            jobs=$(sed -e "s/,/ /g" all_job_ids.log | sed -E "s/project-[0-9A-Za-z]+://g" | xargs)
             dx terminate $jobs
         fi
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -227,6 +227,7 @@ _testing_clean_up () {
 
             if [ -n "$all_outputs" ]; then
                 array_all_outputs=($all_outputs)
+                # for each element of the array, add the project_id as a prefix
                 echo "${array_all_outputs[@]/#/${project_id}:}" | xargs -t dx rm
             fi
         fi
@@ -249,6 +250,12 @@ main () {
     if [ -z "${upload_sentinel_record+x}" ] && [ -z "${fastqs+x}" ]; then
         # requires either sentinel file or fastqs
         _exit "No sentinel file or list of fastqs provided."
+    fi
+
+    if [ -z "${upload_sentinel_record+x}" ]; then
+        if [ "${fastqs+x}" ] && [ -z "${run_id}" ]; then
+            _exit "No run id provided with the fastqs"
+        fi
     fi
 
     if [ "$samplesheet" ]; then


### PR DESCRIPTION
- Conductor will fail if fastqs are provided but no `run_id`
- Prettify config messages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/148)
<!-- Reviewable:end -->
