### PR TITLE
Part 21.3: Fix some bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ OR
 #### **Integers**
 
 - `-itesting_sample_limit`: no. of samples to launch per sample jobs for, useful when testing to not wait on launching all per sample jobs
-- `-imismatch_allowance` (default: `1`): no. of samples allowed to be missing assay code and continue analysis using the assay code of the other samples on the run (i.e. allows for a control sample on the run not named specifically for the assay)
 
 #### **Booleans**
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -110,13 +110,6 @@
       "help": "comma separated string of sample names to exclude from per sample analysis steps"
     },
     {
-      "name": "mismatch_allowance",
-      "label": "mismatch allowance",
-      "class": "int",
-      "default": 1,
-      "help": "no. of samples allowed to not match to any assay code and use the assay code of other samples"
-    },
-    {
       "name": "development",
       "label": "development",
       "class": "boolean",

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -143,14 +143,6 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--mismatch_allowance",
-        type=int,
-        help=(
-            "# of samples allowed to not match to any assay code and use "
-            "the assay code of other samples (default: 1, set in dxapp.json)"
-        ),
-    )
-    parser.add_argument(
         "--job_reuse",
         help=(
             "JSON formatted string mapping analysis step -> job ID to reuse "

--- a/resources/home/dnanexus/run_workflows/tests/test_demultiplexing.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_demultiplexing.py
@@ -25,9 +25,7 @@ def test_set_config_for_demultiplexing_w_core_nb():
         {"demultiplex_config": {"instance_type": "mem1_ssd1_v2_x16"}}
     )
 
-    assert output == {
-        "demultiplex_config": {"instance_type": "mem1_ssd1_v2_x16"}
-    }
+    assert output == {"instance_type": "mem1_ssd1_v2_x16"}
 
 
 def test_set_config_for_demultiplexing_select_highest_core_nb_config():
@@ -37,9 +35,7 @@ def test_set_config_for_demultiplexing_select_highest_core_nb_config():
         {"demultiplex_config": {"instance_type": "mem1_ssd2_v2_x36"}},
     )
 
-    assert output == {
-        "demultiplex_config": {"instance_type": "mem1_ssd1_v2_x72"}
-    }
+    assert output == {"instance_type": "mem1_ssd1_v2_x72"}
 
 
 @patch("utils.demultiplexing.dx.search.find_data_objects")

--- a/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
+++ b/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
@@ -34,7 +34,9 @@ def set_config_for_demultiplexing(*configs):
 
     if core_nbs:
         bigger_core_nb = max(core_nbs)
-        return demultiplex_configs[core_nbs.index(bigger_core_nb)]
+        return demultiplex_configs[core_nbs.index(bigger_core_nb)].get(
+            "demultiplex_config", None
+        )
 
     return
 

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -428,7 +428,7 @@ def preprocess_exclusion_patterns(patterns):
                 )
             )
 
-    return new_patterns
+    return list(new_patterns)
 
 
 def exclude_samples(samples, patterns=[]):

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -328,7 +328,7 @@ main () {
     if [ "$testing_sample_limit" ]; then optional_args+="--testing_sample_limit ${testing_sample_limit} "; fi
     if [ "$mismatch_allowance" ]; then optional_args+="--mismatch_allowance ${mismatch_allowance} "; fi
     if [ "$job_reuse" ]; then optional_args+="--job_reuse ${job_reuse/ /} "; fi
-    if [ "$exclude_samples" ]; then optional_args+="--exclude_samples ${exclude_samples} "; fi
+    if [ "$exclude_samples" ]; then optional_args+="--exclude_samples '${exclude_samples}' "; fi
 
     echo "$optional_args"
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -139,7 +139,7 @@ _parse_sentinel_file () {
         # samplesheet found during upload and associated to sentinel file
         echo "Using samplesheet associated with sentinel record"
         dx download -f "$sentinel_samplesheet" -o SampleSheet.csv
-        SAMPLESHEET="$sentinel_samplesheet"
+        samplesheet="$sentinel_samplesheet"
     else
         # sample sheet missing from sentinel file, most likely due to not being
         # named correctly, download the first tar, unpack and try to find it
@@ -167,8 +167,8 @@ _parse_sentinel_file () {
         else
             # found samplesheet in run data, upload back to project in same dir as sentinel file
             # to be able to get file ID for passing as input for INPUT-SAMPLESHEET
-            SAMPLESHEET=$(dx upload "$samplesheet" --path "$sentinel_path" --brief)
-            dx tag "$SAMPLESHEET" "samplesheet uploaded from eggd_conductor job: ${PARENT_JOB_ID}"
+            samplesheet=$(dx upload "$samplesheet" --path "$sentinel_path" --brief)
+            dx tag "$samplesheet" "samplesheet uploaded from eggd_conductor job: ${PARENT_JOB_ID}"
 
             # move samplesheet to parse sample names from in run_workflows.py
             mv "$local_samplesheet" /home/dnanexus/SampleSheet.csv

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -326,7 +326,6 @@ main () {
     if [ "$development" == 'true' ]; then optional_args+="--development "; fi
     if [ "$testing" == 'true' ]; then optional_args+="--testing "; fi
     if [ "$testing_sample_limit" ]; then optional_args+="--testing_sample_limit ${testing_sample_limit} "; fi
-    if [ "$mismatch_allowance" ]; then optional_args+="--mismatch_allowance ${mismatch_allowance} "; fi
     if [ "$job_reuse" ]; then optional_args+="--job_reuse ${job_reuse/ /} "; fi
     if [ "$exclude_samples" ]; then optional_args+="--exclude_samples '${exclude_samples}' "; fi
 

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -412,7 +412,7 @@ main () {
     for file in /home/dnanexus/out/job_summaries/*; do
         new_name=$(echo "$file" | awk -v OFS="." '{len=split($0, a, "."); print a[1], a[len-1], a[len]}')
         new_name=${new_name##*/}
-        project_to_upload_to=$(echo "$file" | cut -f2- -d"." | cut -f-3 -d".")
+        project_to_upload_to=$(echo "$file" | awk 'BEGIN{FS=OFS="."} {$NF=$(NF-1)=""; NF-=2} 1' | cut -f2- -d".")
         file_id=$(dx upload "${file}" --path "${project_to_upload_to}:/${new_name}" --brief)
 
         dx-jobutil-add-output job_summaries "$file_id" --class=array:file


### PR DESCRIPTION
- Improve printing
- Set the run id variable in the environment for use in the error message
- Fix parsing if the first element in the `exclude_samples` starts with a hyphen
- Stop sending an error message if it occurred in the running job bit and an error message has already been sent
- Remove `mismatch_allowance`
- Fix issue where the demultiplex config was not passed
- Fix parsing of project name when uploading job summary file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/149)
<!-- Reviewable:end -->
