### PR TITLE
Di 1381 fix bug where happy is running for all samples

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/utils/AssayHandler.py
+++ b/resources/home/dnanexus/run_workflows/utils/AssayHandler.py
@@ -463,6 +463,11 @@ class AssayHandler:
                 input_dict=input_dict, upload_tars=self.upload_tars
             )
 
+        # get any filters from config to apply to job inputs
+        input_filter_dict = self.config["executables"][executable].get(
+            "inputs_filter"
+        )
+
         # check any inputs dependent on previous job outputs to add
         input_dict = manage_dict.link_inputs_to_outputs(
             job_outputs_dict=self.job_outputs,
@@ -470,6 +475,7 @@ class AssayHandler:
             analysis=params["analysis"],
             per_sample=per_sample,
             sample=sample,
+            input_filter_dict=input_filter_dict,
         )
 
         # check input types correctly set in input dict


### PR DESCRIPTION
- Add variable to get the `inputs_filter` key from the assay config
- Pass said variable to the `link_inputs_to_outputs` function
- Change version

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/159)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Bumped application version from 2.1.0 to 2.1.1

- **Improvements**
  - Enhanced input handling in AssayHandler with configuration-based input filtering
  - Added flexibility to job input management process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->