### PR TITLE
Di 1382 fix bug where the demultiplex output doesn t have default

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9.21
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9.21
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,11 +5,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9.21
-      uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9.21
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -466,7 +466,7 @@ def main():
             # app config
             demultiplex_app_id = os.environ.get("DEMULTIPLEX_APP_ID")
 
-        demultiplex_job = demultiplex(
+        demultiplex_job, demultiplex_output = demultiplex(
             app_id=demultiplex_app_id,
             app_name=demultiplex_app_name,
             testing=args.testing,
@@ -478,7 +478,7 @@ def main():
 
         for assay_handler in assay_handlers:
             move_demultiplex_qc_files(
-                assay_handler.project.id, *args.demultiplex_output.split(":")
+                assay_handler.project.id, *demultiplex_output.split(":")
             )
 
         fastq_details = get_demultiplex_job_details(demultiplex_job.id)

--- a/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
+++ b/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
@@ -199,7 +199,9 @@ def demultiplex(
                 projects = [project for project in dx.find_projects(run_id)]
 
                 if len(projects) > 1 or len(projects) == 0:
-                    raise Exception(f"Too many projects found using {run_id}")
+                    raise Exception(
+                        f"'{run_id}' found no or multiple projects in DNAnexus"
+                    )
                 else:
                     run_id = projects[0].get("id")
 

--- a/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
+++ b/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
@@ -195,6 +195,14 @@ def demultiplex(
         if not demultiplex_output:
             # running in testing and going to demultiplex -> dump output to
             # our testing analysis project to not go to sentinel file dir
+            if not re.match(r"project-[A-Za-z0-9]", run_id):
+                projects = [project for project in dx.find_projects(run_id)]
+
+                if len(projects) > 1 or len(projects) == 0:
+                    raise Exception(f"Too many projects found using {run_id}")
+                else:
+                    run_id = projects[0].get("id")
+
             demultiplex_output = f"{run_id}:/demultiplex_{time_stamp()}"
 
     (demultiplex_project, demultiplex_folder) = demultiplex_output.split(":")
@@ -320,4 +328,4 @@ def demultiplex(
 
     prettier_print("Demuliplexing completed!")
 
-    return job
+    return job, demultiplex_output


### PR DESCRIPTION
- Pass `demultiplex_output` to the `move_demultiplex_qc_files` function
- Check if the run id is a project-id and change it so if not in order to have correct processing
- Bump github actions checkout and setup-python

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/160)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Chores**
  - Updated GitHub Actions workflow to use the latest versions of checkout and Python setup actions.

- **Bug Fixes**
  - Enhanced error handling and validation in the demultiplexing process.
  - Improved project identification and output management in the demultiplexing workflow.

The updates focus on improving workflow reliability and code clarity without introducing major user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->