### PR TITLE
In 876 app does not handle parsing output of eggd tso500 to multiple downstream inputs

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1297,6 +1297,7 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
             "stage-mosdepth.bam": "eggd_tso500.bam",
             "stage-mosdepth.index": "eggd_tso500.idx",
             "stage-vcf_rescue.gvcf": "eggd_tso500.vcf",
+            "stage-plot_variant_baf.vcf": "eggd_tso500.vcf",
             "stage-generate_variant_workbook.additional_files": "eggd_tso500.cvo",
         }
 
@@ -1401,6 +1402,7 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
                 "stage-mosdepth.bam": {"$dnanexus_link": "file-b1"},
                 "stage-mosdepth.index": {"$dnanexus_link": "file-d1"},
                 "stage-vcf_rescue.gvcf": {"$dnanexus_link": "file-f1"},
+                "stage-plot_variant_baf.vcf": {"$dnanexus_link": "file-f1"},
                 "stage-generate_variant_workbook.additional_files": [
                     {"$dnanexus_link": "file-h1"},
                     {"$dnanexus_link": "file-i1"},
@@ -1432,6 +1434,7 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
                 "stage-mosdepth.bam": {"$dnanexus_link": "file-c1"},
                 "stage-mosdepth.index": {"$dnanexus_link": "file-e1"},
                 "stage-vcf_rescue.gvcf": {"$dnanexus_link": "file-g1"},
+                "stage-plot_variant_baf.vcf": {"$dnanexus_link": "file-g1"},
                 "stage-generate_variant_workbook.additional_files": [
                     {"$dnanexus_link": "file-h3"},
                     {"$dnanexus_link": "file-i1"},


### PR DESCRIPTION
Fix bug where only the first value of tso500 input would get replaced.
Failed job: https://platform.dnanexus.com/panx/projects/Gy7kjxQ4BkjK7p3QgVjy3b0g/monitor/job/GyZy8b84Bkj8kK0Y8jK03Gb0
Functioning job (same inputs, new version): https://platform.dnanexus.com/panx/projects/Gyb2Xk04VzFpj5fJ8v46X9z7/monitor/job/Gyb2j084VzFpy23p59bFQ5fy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/165)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced workflow processing now supports multiple input configurations with individual validation for more reliable output handling.
  - Added support for an additional output file mapping in the input dictionary for improved test validation.
- **Chores**
  - Updated the application version from 2.1.2 to 2.1.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->