### PR TITLE
In 878 conductor fails if sample matching fails completely

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -221,12 +221,14 @@ def main():
         }
 
         nb_provided_configs = len(configs)
+        provided_config = True
 
     else:
         # get all json assay configs from path in conductor config
         configs = get_json_configs()
         configs = filter_highest_config_version(configs)
         nb_provided_configs = 0
+        provided_config = False
 
     if args.exclude_samples:
         prettier_print("Attempting to exclude following samples using:")
@@ -240,7 +242,7 @@ def main():
     assay_to_samples = match_samples_to_assays(
         configs=configs,
         all_samples=args.samples,
-        testing=args.testing,
+        provided_config=provided_config,
     )
 
     assay_handlers = []

--- a/resources/home/dnanexus/run_workflows/tests/test_utils.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_utils.py
@@ -238,7 +238,7 @@ class TestMatchSamplesToAssays:
         assay_samples = match_samples_to_assays(
             configs=self.configs,
             all_samples=self.single_assay_sample_list,
-            testing=False,
+            provided_config=False,
         )
 
         correct_output = {
@@ -282,7 +282,7 @@ class TestMatchSamplesToAssays:
         matches = match_samples_to_assays(
             configs=configs,
             all_samples=self.single_assay_sample_list,
-            testing=False,
+            provided_config=False,
         )
 
         assert list(matches.keys()) == [
@@ -305,7 +305,7 @@ class TestMatchSamplesToAssays:
         matches = match_samples_to_assays(
             configs=configs,
             all_samples=self.single_assay_sample_list,
-            testing=False,
+            provided_config=False,
         )
 
         assert list(matches.keys()) == [
@@ -329,7 +329,9 @@ class TestMatchSamplesToAssays:
             # this should raise an AssertionError as normal for mismatch
             # between total samples and those matching assay config
             match_samples_to_assays(
-                configs=self.configs, all_samples=sample_list, testing=False
+                configs=self.configs,
+                all_samples=sample_list,
+                provided_config=False,
             )
 
     def test_raise_assertion_error_on_sample_w_no_assay_code_match(self):
@@ -341,7 +343,46 @@ class TestMatchSamplesToAssays:
             match_samples_to_assays(
                 configs=self.configs,
                 all_samples=self.sample_list_w_no_code,
-                testing=False,
+                provided_config=False,
+            )
+
+    def test_assign_samples_to_provided_config_if_matching_fails(self):
+        matches = match_samples_to_assays(
+            configs={
+                "EGG2|456": {"assay_code": "EGG2|456", "version": "1.1.0"}
+            },
+            all_samples=[
+                "sample1-0",
+                "sample2-0",
+            ],
+            provided_config=True,
+        )
+
+        correct_output = {
+            "EGG2|456": [
+                "sample1-0",
+                "sample2-0",
+            ]
+        }
+
+        assert (
+            matches == correct_output
+        ), "Samples were not assigned the provided config assay code after failing the matching"
+
+    def test_raise_exception_when_2_configs_are_provided_and_matching_fails(
+        self,
+    ):
+        with pytest.raises(Exception):
+            match_samples_to_assays(
+                configs={
+                    "EGG2|456": {"assay_code": "EGG2|456", "version": "1.1.0"},
+                    "EGG2|123": {"assay_code": "EGG2|123", "version": "1.2.0"},
+                },
+                all_samples=[
+                    "sample1-0",
+                    "sample2-0",
+                ],
+                provided_config=True,
             )
 
 

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -250,7 +250,7 @@ def parse_sample_sheet(samplesheet) -> list:
     return sample_list
 
 
-def match_samples_to_assays(configs, all_samples, testing) -> dict:
+def match_samples_to_assays(configs, all_samples, provided_config) -> dict:
     """
     Match sample list against configs to identify correct config to use
     for each sample
@@ -261,8 +261,9 @@ def match_samples_to_assays(configs, all_samples, testing) -> dict:
         dict of config dicts for each assay
     all_samples : list
         list of samples parsed from samplesheet or specified with --samples
-    testing : bool
-        if running in test mode, if not will perform checks on samples
+    provided_config : bool
+        if a  config has been provided via the CLI, match the samples to its
+        assay code
 
     Returns
     -------
@@ -318,33 +319,35 @@ def match_samples_to_assays(configs, all_samples, testing) -> dict:
             ]
 
             assay_to_samples[latest_config_key].append(sample)
-        else:
-            # no match found, just log this as an AssertionError will be raised
-            # below for all samples that don't have a match
-            prettier_print(f"No matching config file found for {sample} !\n")
 
-    if not testing:
-        # check all samples have an assay code in one of the configs
-        samples_w_codes = [
-            x for y in list(assay_to_samples.values()) for x in y
-        ]
-        samples_without_codes = "\n\t\t".join(
-            [f"`{x}`" for x in sorted(set(all_samples) - set(samples_w_codes))]
-        )
+    # check all samples have an assay code in one of the configs
+    samples_w_codes = [x for y in list(assay_to_samples.values()) for x in y]
+    samples_without_codes = "\n\t\t".join(
+        [f"`{x}`" for x in sorted(set(all_samples) - set(samples_w_codes))]
+    )
 
+    # config(s) were provided from the command line
+    if provided_config:
+        # no sample were able to be matched to the config code
+        if not assay_to_samples:
+            if len(configs) == 1:
+                # if only one config was provided, match samples to the
+                # provided config code
+                for sample in all_samples:
+                    assay_to_samples[all_config_assay_codes[0]] = sample
+
+            else:
+                raise Exception(
+                    "Not all samples were able to be matched to provided "
+                    f"configs: {all_config_assay_codes} vs "
+                    f"{samples_without_codes}"
+                )
+    else:
         assert sorted(all_samples) == sorted(samples_w_codes), Slack().send(
-            f"Could not identify assay code for all samples!\n\n"
-            f"Configs for assay codes found: "
+            "Could not identify assay code for all samples!\n\n"
+            "Configs for assay codes found: "
             f"`{', '.join(all_config_assay_codes)}`\n\nSamples not matching "
             f"any available config:\n\t\t{samples_without_codes}"
-        )
-    else:
-        # running in testing mode, check we found at least one sample to config
-        # to actually run. We expect that not all samples may match since if
-        # TESTING_SAMPLE_LIMIT is specified then only a subset of samples
-        # will be in this dict
-        assert assay_to_samples, Slack().send(
-            "No samples matched to available config files for testing"
         )
 
     prettier_print("Total samples per assay identified:")

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -263,7 +263,7 @@ def match_samples_to_assays(configs, all_samples, provided_config) -> dict:
         list of samples parsed from samplesheet or specified with --samples
     provided_config : bool
         if a  config has been provided via the CLI, match the samples to its
-        assay code
+        assay code if sample assay code matching fails
 
     Returns
     -------

--- a/resources/home/dnanexus/run_workflows/utils/utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/utils.py
@@ -334,7 +334,7 @@ def match_samples_to_assays(configs, all_samples, provided_config) -> dict:
                 # if only one config was provided, match samples to the
                 # provided config code
                 for sample in all_samples:
-                    assay_to_samples[all_config_assay_codes[0]] = sample
+                    assay_to_samples[all_config_assay_codes[0]].append(sample)
 
             else:
                 raise Exception(


### PR DESCRIPTION
- Added logic to assign assay config to samples if one and only assay config is provided via CLI and matching fails