### PR TITLE
In 877 conductor job slack message saying that jobs have not been started when they have

### DIFF
--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -93,7 +93,8 @@ _parse_sentinel_file () {
 
     Globals
         SAMPLESHEET : file ID of samplesheet parsed from sentinel
-            file / upload tars, set as global to be picked up in
+            file / upload tars
+             set as global to be picked up in
             run_workflows.py if INPUT-SAMPLESHEET is set
 
     Arguments
@@ -380,7 +381,7 @@ main () {
     message=":receipt: eggd_conductor:"
 
     while read -r project_id assay version jobs; do
-        if [[ $jobs =~ "0" ]]; then
+        if [[ $jobs = "0" ]]; then
             message+="%0A:black_medium_small_square: :rotating_light: No jobs were launched for:%0A"
         else
             message+="%0A:black_medium_small_square: :white_check_mark: ${jobs} jobs were launched for:%0A"

--- a/src/eggd_conductor.sh
+++ b/src/eggd_conductor.sh
@@ -93,8 +93,7 @@ _parse_sentinel_file () {
 
     Globals
         SAMPLESHEET : file ID of samplesheet parsed from sentinel
-            file / upload tars
-             set as global to be picked up in
+            file / upload tars, set as global to be picked up in
             run_workflows.py if INPUT-SAMPLESHEET is set
 
     Arguments


### PR DESCRIPTION
```shell
if [[ 0 = "0" ]]; then echo "blarg"; fi
blarg
if [[ "0" = "0" ]]; then echo "blarg"; fi
blarg
if [[ 50 = "0" ]]; then echo "blarg"; fi
if [[ 50 = "50" ]]; then echo "blarg"; fi
blarg
```
should be ok

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/167)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Refined the job status evaluation process to ensure that messages accurately indicate when no tasks are initiated. This update delivers more consistent and reliable feedback regarding job statuses, reducing potential confusion. Overall, this improvement ensures a smoother and more transparent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->