### PR TITLE
Inter op data branch

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
+++ b/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
@@ -65,6 +65,8 @@ def move_demultiplex_qc_files(
         "Quality_Metrics.csv",
         "Adapter_Metrics.csv",
         "Top_Unknown_Barcodes.csv",
+        "interop_summary.csv",  # InterOp QC metrics for multiQC
+        "interop_index_summary.csv",
     ]
 
     # need to first create destination folder


### PR DESCRIPTION
Added:
```
        "interop_summary.csv",  # InterOp QC metrics for multiQC
        "interop_index_summary.csv",
```
To demultiplexing.py. This will ensure the InterOp metrics will be placed in the demultiplex_multiqc_files at the root of the analysis project.

Increase the app version from 2.1.3 to 2.2.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/170)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Additional QC files, "interop_summary.csv" and "interop_index_summary.csv", are now included in the demultiplexing results.
- **Chores**
	- Application version updated to 2.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->