### PR TITLE
DI-2341 Fix handling of mixed runs to process assays with hold=false first.

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,14 +430,14 @@ If one or more are missing / invalid, or any error occurs connecting and / or qu
 Example comment added at begining of processing to link to eggd_conductor job:
 
 ```text
-This run was processed automatically by eggd_conductor: http://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/job/GJ3ykQ84Bv42ZP8J5zjz6qBb
+This run was processed automatically by eggd_conductor: https://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/job/GJ3ykQ84Bv42ZP8J5zjz6qBb
 ```
 
 Example comment added at end of successfully launching all jobs with link to analysis project:
 
 ```text
 All jobs sucessfully launched by eggd_conductor.
-Analysis project: http://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/
+Analysis project: https://platform.dnanexus.com/projects/GB3jx784Bv40j3Zx4P5vvbzQ/monitor/
 ```
 
 ---

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -398,7 +398,7 @@ def main():
                             "This run was processed automatically by "
                             "eggd_conductor: "
                         ),
-                        url=f"http://{os.environ.get('conductor_job_url')}",
+                        url=f"https://{os.environ.get('conductor_job_url')}",
                         ticket=ticket["id"],
                     )
 
@@ -551,7 +551,12 @@ def main():
     )
 
     # Sort assay_handlers so those with hold=True are last
-    assay_handlers = sorted(assay_handlers, key=lambda h: h.config.get("hold", False))
+    assay_handlers = sorted(
+        assay_handlers, key=lambda h: manage_dict.is_held(h.config)
+        )
+    print("\nAssay handler order (those with hold=True are last):")
+    for i in assay_handlers:
+        prettier_print(f"Assay handler order: {i} - hold: {i.config.get('hold', '')}")
 
     execution_errors = {}
 

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -550,6 +550,9 @@ def main():
         check=True,
     )
 
+    # Sort assay_handlers so those with hold=True are last
+    assay_handlers = sorted(assay_handlers, key=lambda h: h.config.get("hold", False))
+
     execution_errors = {}
 
     for handler in assay_handlers:

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -554,9 +554,6 @@ def main():
     assay_handlers = sorted(
         assay_handlers, key=lambda h: manage_dict.is_held(h.config)
         )
-    print("\nAssay handler order (those with hold=True are last):")
-    for i in assay_handlers:
-        prettier_print(f"Assay handler order: {i} - hold: {i.config.get('hold', '')}")
 
     execution_errors = {}
 

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -620,7 +620,7 @@ def main():
                         jira.add_comment(
                             comment=f"{msg}\n",
                             url=(
-                                "http://platform.dnanexus.com/panx/projects/"
+                                "https://platform.dnanexus.com/panx/projects/"
                                 f"{handler.project.id.replace('project-', '')}/monitor/"
                             ),
                             ticket=handler.ticket,
@@ -706,7 +706,7 @@ def main():
                     "\nAnalysis project(s): "
                 ),
                 url=(
-                    "http://platform.dnanexus.com/panx/projects/"
+                    "https://platform.dnanexus.com/panx/projects/"
                     f"{handler.project.id.replace('project-', '')}/monitor/"
                 ),
                 ticket=handler.ticket,

--- a/resources/home/dnanexus/run_workflows/run_workflows.py
+++ b/resources/home/dnanexus/run_workflows/run_workflows.py
@@ -551,9 +551,7 @@ def main():
     )
 
     # Sort assay_handlers so those with hold=True are last
-    assay_handlers = sorted(
-        assay_handlers, key=lambda h: manage_dict.is_held(h.config)
-        )
+    assay_handlers = sorted(assay_handlers, key=lambda h: manage_dict.is_held(h.config))
 
     execution_errors = {}
 

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1427,7 +1427,7 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
 class TestIsHeld:
     """
     Tests for is_held() that checks a config dict for presence of
-    "hold" key with value True (bool or str) at any level of nesting
+    "hold" key with value True (bool) at any level of nesting
     """
 
     def test_no_hold_key_present(self):
@@ -1456,7 +1456,7 @@ class TestIsHeld:
         assert is_held(config)
 
     def test_more_nested_hold_true(self):
-        """Test when hold key is nested and True str"""
+        """Test when hold key is nested and True bool"""
         config = {
             "foo": {
                 "bar": {
@@ -1495,7 +1495,7 @@ class TestIsHeld:
     def test_hold_is_int_eq_true(self):
         """
         Test when multiple hold keys and one is int==1
-        expected to be False as only bool True or str 'true'
+        expected to be False as only bool True
         should be treated as hold
         """
         config = {"hold": False, "foo": {"hold": 1}}
@@ -1515,6 +1515,17 @@ class TestIsHeld:
         but another is True
         """
         config = {"hold": True, "foo": {"hold": 0}}
+        assert is_held(config)
+
+    def test_tso500_config_with_hold(self):
+        """
+        Test when hold key is present in typical eggd_tso500
+        config structure
+        """
+        test_tso500_config_path = (
+            "resources/home/dnanexus/run_workflows/tests/data/build_job_inputs/tso500_config.json"
+        )
+        config = json.load(open(test_tso500_config_path))
         assert is_held(config)
 
 

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1562,9 +1562,19 @@ class TestSearchExactKey:
         config = {"behold": "no", "foo": {"holdings": "nope"}}
         assert search_exact_key("hold", config) == []
 
-    def test_value_is_dictionary(self):
+    def test_value_is_list_of_ints_do_not_match(self):
         """Keys containing substring do not match"""
-        config = {"app": "app-id", "hold": {"value": True}}
+        config = {"app": "app-id", "details": {"hold": [1, 2, 3]}}
+        assert search_exact_key("hold", config) == []
+
+    def test_value_is_bool_list_do_not_match(self):
+        """Keys containing list of bools do not match"""
+        config = {"app": "app-id", "details": {"hold": [True, False, False]}}
+        assert search_exact_key("hold", config) == []
+
+    def test_value_is_dict(self):
+        """Keys of hold with value as dict do not match"""
+        config = {"app": "app-id", "details": {"hold": {"key": True}}}
         assert search_exact_key("hold", config) == []
 
     def test_list_of_dicts(self):

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1430,29 +1430,24 @@ class TestIsHeld:
     "hold" key with value True (bool or str) at any level of nesting
     """
 
-    def test_no_hold_key(self):
+    def test_no_hold_key_present(self):
         """Test when no hold key anywhere"""
         config = {"foo": 10, "bar": {"baz": 20}}
         assert not is_held(config)
 
-    def test_hold_false_bool(self):
+    def test_hold_false(self):
         """Test when hold key==False"""
         config = {"hold": False}
         assert not is_held(config)
 
-    def test_hold_true_bool(self):
+    def test_hold_true(self):
         """Test when hold key==True"""
         config = {"hold": True}
         assert is_held(config)
 
-    def test_hold_true_str(self):
-        """Test when hold key=='True' string"""
+    def test_hold_false_when_str(self):
+        """Test still false when hold key is 'True' string"""
         config = {"hold": "true"}
-        assert is_held(config)
-
-    def test_hold_false_str(self):
-        """Test when hold key=='False' string"""
-        config = {"hold": "false"}
         assert not is_held(config)
 
     def test_nested_hold_true(self):
@@ -1460,21 +1455,16 @@ class TestIsHeld:
         config = {"foo": {"bar": {"hold": True}}}
         assert is_held(config)
 
-    def test_nested_hold_true_str(self):
+    def test_more_nested_hold_true(self):
         """Test when hold key is nested and True str"""
         config = {
             "foo": {
                 "bar": {
                     "app": "app-id",
-                    "executable": {"name": "app-name", "hold": "true"},
+                    "executable": {"name": "app-name", "options": {"hold": True}},
                 }
             }
         }
-        assert is_held(config)
-
-    def test_very_nested_hold_true_str(self):
-        """Test when hold key is very nested and True bool"""
-        config = {"foo": {"bar": {"hold": "true"}}}
         assert is_held(config)
 
     def test_list_of_dicts_with_hold(self):
@@ -1489,22 +1479,17 @@ class TestIsHeld:
 
     def test_multiple_holds_one_true(self):
         """Test when multiple hold keys and one is True"""
-        config = {"hold": False, "foo": {"hold": "true"}}
+        config = {"hold": False, "foo": {"hold": True}}
         assert is_held(config)
 
     def test_multiple_holds_all_false(self):
         """Test when multiple hold keys and all are False"""
-        config = {"hold": False, "foo": {"hold": "false"}}
+        config = {"hold": False, "foo": {"hold": False}}
         assert not is_held(config)
 
     def test_only_hold_key_is_int(self):
         """Test when only hold key and is int"""
         config = {"hold": 10}
-        assert not is_held(config)
-
-    def test_hold_is_int(self):
-        """Test when multiple hold keys and one is int"""
-        config = {"hold": False, "foo": {"hold": 10}}
         assert not is_held(config)
 
     def test_hold_is_int_eq_true(self):
@@ -1517,12 +1502,16 @@ class TestIsHeld:
         assert not is_held(config)
 
     def test_hold_is_int_eq_false(self):
-        """Test when multiple hold keys and one is int==0"""
+        """
+        Test when multiple hold keys and one is int==0
+        but another is False
+        """
         config = {"hold": False, "foo": {"hold": 0}}
         assert not is_held(config)
 
     def test_hold_is_int_eq_false_but_true_present(self):
-        """Test when multiple hold keys and one is int==0
+        """
+        Test when multiple hold keys and one is int==0
         but another is True
         """
         config = {"hold": True, "foo": {"hold": 0}}

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1430,92 +1430,199 @@ class TestIsHeld:
     "hold" key with value True (bool) at any level of nesting
     """
 
-    def test_no_hold_key_present(self):
-        """Test when no hold key anywhere"""
-        config = {"foo": 10, "bar": {"baz": 20}}
-        assert not is_held(config)
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            ({"foo": 10, "bar": {"baz": 20}}, False),
+            ({"foo": 10, "bar": {"threshold": 20}}, False),
+            ({"foo": True, "bar": {"baz": True}}, False),
+        ],
+    )
+    def test_no_hold_key_present(self, config, expected):
+        assert is_held(config) == expected
 
-    def test_hold_false(self):
-        """Test when hold key==False"""
-        config = {"hold": False}
-        assert not is_held(config)
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            # hold key False
+            ({"hold": False}, False),
+            # hold key True
+            ({"hold": True}, True),
+            # hold key as string
+            ({"hold": "true"}, False),
+            # Nested hold True
+            ({"foo": {"bar": {"hold": True}}}, True),
+            # Key ending with hold is not used
+            ({"foo": [{"threshold": True}]}, False),
+            # Only hold key is int
+            ({"hold": 10}, False),
+            # Multiple holds, one is int==1
+            ({"hold": False, "foo": {"hold": 1}}, False),
+            # Multiple holds, one is int==0
+            ({"hold": False, "foo": {"hold": 0}}, False),
+            # Multiple holds, int==0 but True present
+            ({"hold": True, "foo": {"hold": 0}}, True),
+        ],
+    )
+    def test_is_held_simple_cases(self, config, expected):
+        assert is_held(config) == expected
 
-    def test_hold_true(self):
-        """Test when hold key==True"""
-        config = {"hold": True}
-        assert is_held(config)
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            # List of dicts with hold True and False
+            ({"foo": [{"hold": True}, {"hold": False}]}, True),
+            # List of dicts with hold True, False, int, string
+            ({"foo": [{"hold": True}, {"hold": False}, {"hold": 1}, {"hold": "true"}]}, True),
+            # List of dicts with hold all False/invalid
+            ({"foo": [{"hold": False}, {"hold": 0}, {"hold": "false"}]}, False),
+            # hold key in list of dicts, all False
+            ({"foo": [{"hold": False}, {"hold": False}]}, False),
+            # hold key in list of dicts, one True
+            ({"foo": [{"hold": False}, {"hold": True}]}, True),
+        ],
+    )
+    def test_is_held_list_of_dicts(self, config, expected):
+        assert is_held(config) == expected
 
-    def test_hold_false_when_str(self):
-        """Test still false when hold key is 'True' string"""
-        config = {"hold": "true"}
-        assert not is_held(config)
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            # hold key in list of dicts, True as string
+            ({"foo": [{"hold": "True"}, {"hold": "False"}]}, False),
+            # hold key in list of dicts, True as int
+            ({"foo": [{"hold": 1}, {"hold": 0}]}, False),
+            # hold key in list of dicts, True as bool and int
+            ({"foo": [{"hold": True}, {"hold": 1}]}, True),
+            # hold key in list of dicts, True as bool and string
+            ({"foo": [{"hold": True}, {"hold": "True"}]}, True),
+            # hold key in list of dicts, True as bool and False as string
+            ({"foo": [{"hold": True}, {"hold": "False"}]}, True),
+            # hold key in list of dicts, True as bool and False as int
+            ({"foo": [{"hold": True}, {"hold": 0}]}, True),
+        ],
+    )
+    def test_is_held_mixed_types(self, config, expected):
+        assert is_held(config) == expected
 
-    def test_nested_hold_true(self):
-        """Test when hold key is nested and True bool"""
-        config = {"foo": {"bar": {"hold": True}}}
-        assert is_held(config)
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            # Multiple holds, one True
+            ({"hold": False, "foo": {"hold": True}}, True),
+            # Multiple holds, all False
+            ({"hold": False, "foo": {"hold": False}}, False),
+            # Multiple holds, one True string, one True bool
+            ({"hold": "True", "foo": {"hold": True}}, True),
+            # Multiple holds, one True string, one False bool
+            ({"hold": "True", "foo": {"hold": False}}, False),
+        ],
+    )
+    def test_is_held_multiple_holds(self, config, expected):
+        assert is_held(config) == expected
 
-    def test_more_nested_hold_true(self):
-        """Test when hold key is nested and True bool"""
-        config = {
-            "foo": {
-                "bar": {
-                    "app": "app-id",
-                    "executable": {"name": "app-name", "options": {"hold": True}},
-                }
-            }
-        }
-        assert is_held(config)
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            # More nested hold True
+            (
+                {
+                    "foo": {
+                        "bar": {
+                            "app": "app-id",
+                            "executable": {"name": "app-name", "options": {"hold": True}},
+                        }
+                    }
+                },
+                True,
+            ),
+            # More nested hold False
+            (
+                {
+                    "foo": {
+                        "bar": {
+                            "app": "app-id",
+                            "executable": {"name": "app-name", "options": {"hold": False}},
+                        }
+                    }
+                },
+                False,
+            ),
+            # More nested hold as string
+            (
+                {
+                    "foo": {
+                        "bar": {
+                            "app": "app-id",
+                            "executable": {"name": "app-name", "options": {"hold": "True"}},
+                        }
+                    }
+                },
+                False,
+            ),
+            # More nested hold as int
+            (
+                {
+                    "foo": {
+                        "bar": {
+                            "app": "app-id",
+                            "executable": {"name": "app-name", "options": {"hold": 1}},
+                        }
+                    }
+                },
+                False,
+            ),
+            # Nested hold within list of dicts
+            (
+                {
+                    "foo": {
+                        "bar": {
+                            "app": "app-id",
+                            "executables": [
+                                {"name": "app-name", "options": {"hold": True}},
+                                {"name": "app-name2", "options": {"hold": False}},
+                                {"name": "app-name3", "options": {"hold": False}}
+                            ]
+                        }
+                    }
+                },
+                True,
+            ),
+        ],
+    )
+    def test_different_levels_of_nested_hold(self, config, expected):
+        assert is_held(config) == expected
 
-    def test_list_of_dicts_with_hold(self):
-        """Test when hold key is nested in list with True and False bool"""
-        config = {"foo": [{"hold": True}, {"hold": False}]}
-        assert is_held(config)
-
-    def test_key_ending_with_hold_is_not_used(self):
+    @pytest.mark.parametrize(
+        "config, expected",
+        [
+            ({"foo": [{"threshold": True}]}, False),
+            ({"bar": {"threshold": False}}, False),
+            ({"baz": {"threshold": 1}}, False),
+            ({"foo": [{"threshold": True}, {"threshold": False}]}, False),
+            ({"holding": [{"threshold": 0}, {"threshold": 1}]}, False),
+        ],
+    )
+    def test_key_ending_with_hold_is_not_used(self, config, expected):
         """Test when key ends with 'hold' but is not 'hold'"""
-        config = {"foo": [{"threshold": True}]}
-        assert not is_held(config)
+        assert is_held(config) == expected
 
-    def test_multiple_holds_one_true(self):
-        """Test when multiple hold keys and one is True"""
-        config = {"hold": False, "foo": {"hold": True}}
-        assert is_held(config)
-
-    def test_multiple_holds_all_false(self):
-        """Test when multiple hold keys and all are False"""
-        config = {"hold": False, "foo": {"hold": False}}
-        assert not is_held(config)
-
-    def test_only_hold_key_is_int(self):
-        """Test when only hold key and is int"""
-        config = {"hold": 10}
-        assert not is_held(config)
-
-    def test_hold_is_int_eq_true(self):
+    def test_case_sensitive(self):
         """
-        Test when multiple hold keys and one is int==1
-        expected to be False as only bool True
-        should be treated as hold
+        Test that key is case-sensitive and only 'hold' (lowercase)
+        is used
         """
-        config = {"hold": False, "foo": {"hold": 1}}
-        assert not is_held(config)
-
-    def test_hold_is_int_eq_false(self):
-        """
-        Test when multiple hold keys and one is int==0
-        but another is False
-        """
-        config = {"hold": False, "foo": {"hold": 0}}
-        assert not is_held(config)
-
-    def test_hold_is_int_eq_false_but_true_present(self):
-        """
-        Test when multiple hold keys and one is int==0
-        but another is True
-        """
-        config = {"hold": True, "foo": {"hold": 0}}
-        assert is_held(config)
+        test_configs = [
+            {"Hold": True},
+            {"HOLD": True},
+            {"hOld": True},
+            {"hoLD": True},
+            {"hoLd": True},
+            {"hOLd": True},
+            {"holD": True},
+        ]
+        for config in test_configs:
+            assert not is_held(config), f"Key case sensitivity failed for {config}"
 
     def test_tso500_config_with_hold(self):
         """
@@ -1529,62 +1636,41 @@ class TestIsHeld:
             config = json.load(fh)
         assert is_held(config)
 
-
 class TestSearchExactKey:
     """
-    Tests for search_exact_key to ensure it matches only keys named exactly as the identifier,
-    regardless of nesting, and returns their values.
+    Tests for search_exact_key() that searches a config dict for presence of
+    an exact key at any level of nesting and returns a list of all values
+    found for that key
     """
-
-    def test_no_match(self):
-        """No matching key present"""
-        config = {"foo": 1, "bar": {"baz": 2}}
-        assert search_exact_key("hold", config) == []
-
-    def test_top_level_match(self):
-        """Top-level key matches"""
-        config = {"hold": True, "foo": 1}
-        assert search_exact_key("hold", config) == [True]
-
-    def test_nested_match(self):
-        """Nested key matches"""
-        config = {"foo": {"hold": "yes"}}
-        assert search_exact_key("hold", config) == ["yes"]
-
-    def test_multiple_matches(self):
-        """Multiple keys match"""
-        config = {"hold": False, "foo": {"hold": True}}
-        result = search_exact_key("hold", config)
-        assert set(result) == {False, True}
-
-    def test_key_substring_not_match(self):
-        """Keys containing substring do not match"""
-        config = {"threshold": 0.5, "foo": {"holdings": True}}
-        assert search_exact_key("hold", config) == []
-
-    def test_value_of_list_of_ints_do_not_match(self):
-        """Keys containing list of ints do not match"""
-        config = {"app": "app-id", "details": {"hold": [1, 2, 3]}}
-        assert search_exact_key("hold", config) == []
-
-    def test_value_of_bool_list_do_not_match(self):
-        """Keys containing list of bools do not match"""
-        config = {"app": "app-id", "details": {"hold": [True, False, False]}}
-        assert search_exact_key("hold", config) == []
-
-    def test_value_is_dict_with_non_hold_last_key(self):
-        """Keys of hold with value as dict do not match"""
-        config = {"app": "app-id", "details": {"hold": {"key": True}}}
-        assert search_exact_key("hold", config) == []
-
-    def test_list_of_dicts_with_ints(self):
-        """List of dicts with matching key"""
-        config = {"foo": [{"hold": 1}, {"hold": 2}]}
-        result = search_exact_key("hold", config)
-        assert set(result) == {1, 2}
-
-    def test_list_of_dicts_with_bools(self):
-        """List of dicts with matching key"""
-        config = {"foo": [{"hold": True}, {"hold": False}]}
-        result = search_exact_key("hold", config)
-        assert set(result) == {True, False}
+    @pytest.mark.parametrize(
+        "config, identifier, expected",
+        [
+            # No matching key present
+            ({"foo": 1, "bar": {"baz": 2}}, "hold", []),
+            # Top-level key matches
+            ({"hold": True, "foo": 1}, "hold", [True]),
+            # Nested key matches
+            ({"foo": {"hold": "yes"}}, "hold", ["yes"]),
+            # Multiple keys match
+            ({"hold": False, "foo": {"hold": True}}, "hold", [False, True]),
+            # Keys containing substring do not match
+            ({"threshold": 0.5, "foo": {"holdings": True}}, "hold", []),
+            # Keys containing list of ints do not match
+            ({"app": "app-id", "details": {"hold": [1, 2, 3]}}, "hold", []),
+            # Keys containing list of bools do not match
+            ({"app": "app-id", "details": {"hold": [True, False, False]}}, "hold", []),
+            # Keys of hold with value as dict do not match
+            ({"app": "app-id", "details": {"hold": {"key": True}}}, "hold", []),
+            # List of dicts with matching key (ints)
+            ({"foo": [{"hold": 1}, {"hold": 2}]}, "hold", [1, 2]),
+            # List of dicts with matching key (bools)
+            ({"foo": [{"hold": True}, {"hold": False}]}, "hold", [True, False]),
+        ],
+    )
+    def test_search_exact_key(self, config, identifier, expected):
+        result = search_exact_key(identifier, config)
+        # For cases with multiple matches, compare as sets
+        if isinstance(expected, list) and len(expected) > 1:
+            assert set(result) == set(expected)
+        else:
+            assert result == expected

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1559,26 +1559,32 @@ class TestSearchExactKey:
 
     def test_key_substring_not_match(self):
         """Keys containing substring do not match"""
-        config = {"behold": "no", "foo": {"holdings": "nope"}}
+        config = {"threshold": 0.5, "foo": {"holdings": True}}
         assert search_exact_key("hold", config) == []
 
-    def test_value_is_list_of_ints_do_not_match(self):
+    def test_value_of_list_of_ints_do_not_match(self):
         """Keys containing substring do not match"""
         config = {"app": "app-id", "details": {"hold": [1, 2, 3]}}
         assert search_exact_key("hold", config) == []
 
-    def test_value_is_bool_list_do_not_match(self):
+    def test_value_of_bool_list_do_not_match(self):
         """Keys containing list of bools do not match"""
         config = {"app": "app-id", "details": {"hold": [True, False, False]}}
         assert search_exact_key("hold", config) == []
 
-    def test_value_is_dict(self):
+    def test_value_is_dict_with_non_hold_last_key(self):
         """Keys of hold with value as dict do not match"""
         config = {"app": "app-id", "details": {"hold": {"key": True}}}
         assert search_exact_key("hold", config) == []
 
-    def test_list_of_dicts(self):
+    def test_list_of_dicts_with_ints(self):
         """List of dicts with matching key"""
         config = {"foo": [{"hold": 1}, {"hold": 2}]}
         result = search_exact_key("hold", config)
         assert set(result) == {1, 2}
+
+    def test_list_of_dicts_with_bools(self):
+        """List of dicts with matching key"""
+        config = {"foo": [{"hold": True}, {"hold": False}]}
+        result = search_exact_key("hold", config)
+        assert set(result) == {True, False}

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1563,7 +1563,7 @@ class TestSearchExactKey:
         assert search_exact_key("hold", config) == []
 
     def test_value_of_list_of_ints_do_not_match(self):
-        """Keys containing substring do not match"""
+        """Keys containing list of ints do not match"""
         config = {"app": "app-id", "details": {"hold": [1, 2, 3]}}
         assert search_exact_key("hold", config) == []
 

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1522,10 +1522,11 @@ class TestIsHeld:
         Test when hold key is present in typical eggd_tso500
         config structure
         """
-        test_tso500_config_path = (
-            "resources/home/dnanexus/run_workflows/tests/data/build_job_inputs/tso500_config.json"
+        test_tso500_config_path = os.path.join(
+            TEST_DATA_DIR, "build_job_inputs", "tso500_config.json"
         )
-        config = json.load(open(test_tso500_config_path))
+        with open(test_tso500_config_path) as fh:
+            config = json.load(fh)
         assert is_held(config)
 
 

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -17,6 +17,7 @@ from utils.manage_dict import (
     fix_invalid_inputs,
     check_all_inputs,
     populate_tso500_reports_workflow,
+    is_held,
 )
 from .settings import TEST_DATA_DIR
 
@@ -45,9 +46,9 @@ class TestSearchDict:
 
         correct_output = ["A_level1", "B_level1", "C_level1"]
 
-        assert (
-            sorted(output) == correct_output
-        ), 'Wrong keys returned checking keys with identifier "level1"'
+        assert sorted(output) == correct_output, (
+            'Wrong keys returned checking keys with identifier "level1"'
+        )
 
     def test_search_key_return_value_level1(self) -> None:
         """
@@ -75,9 +76,9 @@ class TestSearchDict:
             "C_array1_value3",
         ]
 
-        assert (
-            sorted(output) == correct_output
-        ), 'Wrong values returned checking keys with identifier "level1"'
+        assert sorted(output) == correct_output, (
+            'Wrong values returned checking keys with identifier "level1"'
+        )
 
     def test_search_key_return_array_values(self) -> None:
         """
@@ -97,9 +98,9 @@ class TestSearchDict:
             "A_level3_array_value4",
         ]
 
-        assert (
-            sorted(output) == correct_output
-        ), "Wrong values returned checking array of values"
+        assert sorted(output) == correct_output, (
+            "Wrong values returned checking array of values"
+        )
 
     def test_search_dict_array(self) -> None:
         """
@@ -119,9 +120,9 @@ class TestSearchDict:
             "C_array1_value3",
         ]
 
-        assert (
-            sorted(output) == correct_output
-        ), "Wrong values returned checking array of dict values"
+        assert sorted(output) == correct_output, (
+            "Wrong values returned checking array of dict values"
+        )
 
 
 class TestReplaceDict:
@@ -146,9 +147,7 @@ class TestReplaceDict:
         )
 
         # replacing all level1 keys with same so should only be one key
-        assert list(output.keys()) == [
-            "test"
-        ], "Replacing level1 keys not correct"
+        assert list(output.keys()) == ["test"], "Replacing level1 keys not correct"
 
     def test_replace_all_value1(self):
         """
@@ -190,9 +189,9 @@ class TestReplaceDict:
             },
         ]
 
-        assert (
-            list(output.values()) == correct_output
-        ), "Searching and replacing 'value1' output incorrect"
+        assert list(output.values()) == correct_output, (
+            "Searching and replacing 'value1' output incorrect"
+        )
 
     def test_replace_value_from_key(self):
         """
@@ -234,9 +233,9 @@ class TestReplaceDict:
             },
         }
 
-        assert (
-            output == correct_output
-        ), "Searching keys and replacing values returned wrong output"
+        assert output == correct_output, (
+            "Searching keys and replacing values returned wrong output"
+        )
 
 
 class TestAddFastqs(unittest.TestCase):
@@ -293,9 +292,7 @@ class TestAddFastqs(unittest.TestCase):
             "analysis": "analysis_2",
             "process_fastqs": True,
             "inputs": {"fastqs": "INPUT-R1-R2"},
-            "output_dirs": {
-                "applet-FvyXygj433GbKPPY0QY8ZKQG": "/OUT-FOLDER/APP-NAME"
-            },
+            "output_dirs": {"applet-FvyXygj433GbKPPY0QY8ZKQG": "/OUT-FOLDER/APP-NAME"},
         },
     }
 
@@ -305,15 +302,11 @@ class TestAddFastqs(unittest.TestCase):
         """
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"][
-                    "inputs"
-                ]
+                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"]["inputs"]
             ),
             fastq_details=self.fastq_details,
         )
-        output_R1_fastqs = output[
-            "stage-G0qpXy0433Gv75XbPJ3xj8jV.reads_fastqgzs"
-        ]
+        output_R1_fastqs = output["stage-G0qpXy0433Gv75XbPJ3xj8jV.reads_fastqgzs"]
 
         correct_R1_fastqs = [
             {"$dnanexus_link": "file-GGJY9604p3zBzjz5Fp66KF0Y"},
@@ -322,9 +315,7 @@ class TestAddFastqs(unittest.TestCase):
             {"$dnanexus_link": "file-GGJY97j4p3z250PB1yvZj7YF"},
         ]
 
-        assert (
-            output_R1_fastqs == correct_R1_fastqs
-        ), "R1 fastqs not correctly added"
+        assert output_R1_fastqs == correct_R1_fastqs, "R1 fastqs not correctly added"
 
     def test_adding_all_r2(self):
         """
@@ -332,15 +323,11 @@ class TestAddFastqs(unittest.TestCase):
         """
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"][
-                    "inputs"
-                ]
+                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"]["inputs"]
             ),
             fastq_details=self.fastq_details,
         )
-        output_R2_fastqs = output[
-            "stage-G0qpXy0433Gv75XbPJ3xj8jV.reads2_fastqgzs"
-        ]
+        output_R2_fastqs = output["stage-G0qpXy0433Gv75XbPJ3xj8jV.reads2_fastqgzs"]
 
         correct_R2_fastqs = [
             {"$dnanexus_link": "file-GGJY9684p3zG6fvf1vqvbqzx"},
@@ -349,9 +336,7 @@ class TestAddFastqs(unittest.TestCase):
             {"$dnanexus_link": "file-GGJY9804p3z1X9YZJ4xf5v13"},
         ]
 
-        assert (
-            output_R2_fastqs == correct_R2_fastqs
-        ), "R2 fastqs not correctly added"
+        assert output_R2_fastqs == correct_R2_fastqs, "R2 fastqs not correctly added"
 
     def test_adding_all_r1_and_r2(self):
         """
@@ -360,9 +345,7 @@ class TestAddFastqs(unittest.TestCase):
         """
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"][
-                    "inputs"
-                ]
+                self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"]["inputs"]
             ),
             fastq_details=self.fastq_details,
         )
@@ -379,9 +362,7 @@ class TestAddFastqs(unittest.TestCase):
             {"$dnanexus_link": "file-GGJY9804p3z1X9YZJ4xf5v13"},
         ]
 
-        assert (
-            output_fastqs == correct_fastqs
-        ), "R1-R2 fastqs not correctly added"
+        assert output_fastqs == correct_fastqs, "R1-R2 fastqs not correctly added"
 
     def test_adding_per_sample_r1_fastqs(self):
         """
@@ -390,24 +371,18 @@ class TestAddFastqs(unittest.TestCase):
         """
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"][
-                    "inputs"
-                ]
+                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"]["inputs"]
             ),
             fastq_details=self.fastq_details,
             sample="2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2",
         )
-        output_R1_fastqs = output[
-            "stage-G0qpXy0433Gv75XbPJ3xj8jV.reads_fastqgzs"
-        ]
+        output_R1_fastqs = output["stage-G0qpXy0433Gv75XbPJ3xj8jV.reads_fastqgzs"]
 
-        correct_R1_fastqs = [
-            {"$dnanexus_link": "file-GGJY9704p3z9P41f80bfQ623"}
-        ]
+        correct_R1_fastqs = [{"$dnanexus_link": "file-GGJY9704p3z9P41f80bfQ623"}]
 
-        assert (
-            output_R1_fastqs == correct_R1_fastqs
-        ), "R1 fastqs not correctly added for given sample"
+        assert output_R1_fastqs == correct_R1_fastqs, (
+            "R1 fastqs not correctly added for given sample"
+        )
 
     def test_adding_per_sample_r2_fastqs(self):
         """
@@ -416,24 +391,18 @@ class TestAddFastqs(unittest.TestCase):
         """
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"][
-                    "inputs"
-                ]
+                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"]["inputs"]
             ),
             fastq_details=self.fastq_details,
             sample="2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2",
         )
-        output_R2_fastqs = output[
-            "stage-G0qpXy0433Gv75XbPJ3xj8jV.reads2_fastqgzs"
-        ]
+        output_R2_fastqs = output["stage-G0qpXy0433Gv75XbPJ3xj8jV.reads2_fastqgzs"]
 
-        correct_R2_fastqs = [
-            {"$dnanexus_link": "file-GGJY9784p3z78j8F1qkp4GZ4"}
-        ]
+        correct_R2_fastqs = [{"$dnanexus_link": "file-GGJY9784p3z78j8F1qkp4GZ4"}]
 
-        assert (
-            output_R2_fastqs == correct_R2_fastqs
-        ), "R2 fastqs not correctly added for given sample"
+        assert output_R2_fastqs == correct_R2_fastqs, (
+            "R2 fastqs not correctly added for given sample"
+        )
 
     def test_adding_all_r1_and_r2_for_one_sample(self):
         """
@@ -442,9 +411,7 @@ class TestAddFastqs(unittest.TestCase):
         """
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"][
-                    "inputs"
-                ]
+                self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"]["inputs"]
             ),
             fastq_details=self.fastq_details,
             sample="2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2",
@@ -456,9 +423,9 @@ class TestAddFastqs(unittest.TestCase):
             {"$dnanexus_link": "file-GGJY9784p3z78j8F1qkp4GZ4"},
         ]
 
-        assert (
-            output_fastqs == correct_fastqs
-        ), "R1-R2 fastqs not correctly added for given sample"
+        assert output_fastqs == correct_fastqs, (
+            "R1-R2 fastqs not correctly added for given sample"
+        )
 
     def test_assert_equal_number_fastqs(self):
         """
@@ -477,9 +444,7 @@ class TestAddFastqs(unittest.TestCase):
         with pytest.raises(AssertionError):
             add_fastqs(
                 input_dict=deepcopy(
-                    self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"][
-                        "inputs"
-                    ]
+                    self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"]["inputs"]
                 ),
                 fastq_details=fastq_details_copy,
             )
@@ -492,9 +457,7 @@ class TestAddFastqs(unittest.TestCase):
         with pytest.raises(AssertionError):
             add_fastqs(
                 input_dict=deepcopy(
-                    self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"][
-                        "inputs"
-                    ]
+                    self.test_input_dict["applet-FvyXygj433GbKPPY0QY8ZKQG"]["inputs"]
                 ),
                 fastq_details=self.fastq_details,
                 sample="test-sample",
@@ -527,9 +490,7 @@ class TestAddFastqs(unittest.TestCase):
 
         output = add_fastqs(
             input_dict=deepcopy(
-                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"][
-                    "inputs"
-                ]
+                self.test_input_dict["workflow-GB6J7qQ433Gkf0ZYGbKfF0x6"]["inputs"]
             ),
             fastq_details=fastq_details,
             sample="2207714-22222Z0110-1-BM-MPD-MYE-M-EGG2",
@@ -579,17 +540,15 @@ class TestAddUploadTars:
         {"$dnanexus_link": "file-GGyqgF84X7kY0fjZBk6jb68P"},
     ]
 
-    parsed_dict = add_upload_tars(
-        input_dict=input_dict, upload_tars=upload_tars
-    )
+    parsed_dict = add_upload_tars(input_dict=input_dict, upload_tars=upload_tars)
 
     def test_adding_upload_tars(self):
         """
         Test that INPUT-UPLOAD_TARS is replaced by the list of file IDs
         """
-        assert (
-            self.parsed_dict.get("input_files") == self.upload_tars
-        ), "Upload tars not correctly added to input dict"
+        assert self.parsed_dict.get("input_files") == self.upload_tars, (
+            "Upload tars not correctly added to input dict"
+        )
 
 
 class TestAddOtherInputs:
@@ -646,57 +605,55 @@ class TestAddOtherInputs:
         """
         Test for finding INPUT-SAMPLE-NAME and replacing with sample name
         """
-        assert (
-            other_inputs["sample_name"] == "my_sample_with_a_long_name"
-        ), "INPUT-SAMPLE-NAME not correctly replaced"
+        assert other_inputs["sample_name"] == "my_sample_with_a_long_name", (
+            "INPUT-SAMPLE-NAME not correctly replaced"
+        )
 
     def test_adding_sample_prefix(self, other_inputs):
         """
         Test for finding INPUT-SAMPLE-PREFIX and replacing with sample prefix
         """
-        assert (
-            other_inputs["sample_name_prefix"] == "my_sample"
-        ), "INPUT-SAMPLE-PREFIX not correctly replaced"
+        assert other_inputs["sample_name_prefix"] == "my_sample", (
+            "INPUT-SAMPLE-PREFIX not correctly replaced"
+        )
 
     def test_adding_project_id(self, other_inputs):
         """
         Test for finding INPUT-dx_project_id and replacing with project_id
         from args Namespace object
         """
-        assert (
-            other_inputs["my_project_id"] == "project-12345"
-        ), "INPUT-dx_project_id not correctly replaced"
+        assert other_inputs["my_project_id"] == "project-12345", (
+            "INPUT-dx_project_id not correctly replaced"
+        )
 
     def test_adding_project_name(self, other_inputs):
         """
         Test for finding INPUT-dx_project_name and replacing with project_name
         from args Namespace object
         """
-        assert (
-            other_inputs["my_project_name"] == "some_analysis_project"
-        ), "INPUT-dx_project_name not correctly replaced"
+        assert other_inputs["my_project_name"] == "some_analysis_project", (
+            "INPUT-dx_project_name not correctly replaced"
+        )
 
     def test_adding_parent_out_dir(self, other_inputs):
         """
         Test for finding INPUT-parent_out_dir and replacing with parent output
         directory from args Namespace object
         """
-        assert (
-            other_inputs["all_analysis_output"] == "some_assay-220930-1200"
-        ), "INPUT-parent_out_dir not correctly replaced"
+        assert other_inputs["all_analysis_output"] == "some_assay-220930-1200", (
+            "INPUT-parent_out_dir not correctly replaced"
+        )
 
     def test_adding_samplesheet(self, other_inputs):
         """
         Test for finding and replacing INPUT-SAMPLESHEET from SAMPLESHEET
         environment variable which will be the dnanexus file ID
         """
-        correct_samplesheet = {
-            "$dnanexus_link": "file-GGxPVxQ4X7kbkFBx7b913b0G"
-        }
+        correct_samplesheet = {"$dnanexus_link": "file-GGxPVxQ4X7kbkFBx7b913b0G"}
 
-        assert (
-            other_inputs["run_sample_sheet"] == correct_samplesheet
-        ), "Samplesheet not correctly parsed to input dict"
+        assert other_inputs["run_sample_sheet"] == correct_samplesheet, (
+            "Samplesheet not correctly parsed to input dict"
+        )
 
     def test_adding_analysis_1_out_dir(self, other_inputs):
         """
@@ -704,9 +661,9 @@ class TestAddOtherInputs:
         output path stored in the analysis output directories dictionary
         """
         correct_path = "/out_dir/dir1"
-        assert (
-            other_inputs["output_path"] == correct_path
-        ), "INPUT-analysis_1-out_dir not correctly replaced"
+        assert other_inputs["output_path"] == correct_path, (
+            "INPUT-analysis_1-out_dir not correctly replaced"
+        )
 
     def test_attempting_to_get_analysis_1_in_job_outputs_doesnt_work(self):
         """
@@ -765,9 +722,9 @@ class TestGetDependentJobs:
             "job-GGjgz1j4Bv48yF89GpZ6zkGz",
         ]
 
-        assert (
-            sorted(jobs) == sample_jobs
-        ), "Failed to get correct dependent jobs per sample"
+        assert sorted(jobs) == sample_jobs, (
+            "Failed to get correct dependent jobs per sample"
+        )
 
     def test_per_run_get_analysis_1_jobs(self):
         """
@@ -776,18 +733,16 @@ class TestGetDependentJobs:
         """
         params = {"depends_on": ["analysis_1"]}
 
-        jobs = get_dependent_jobs(
-            params=params, job_outputs_dict=self.job_outputs_dict
-        )
+        jobs = get_dependent_jobs(params=params, job_outputs_dict=self.job_outputs_dict)
 
         analysis_1_jobs = [
             "analysis-GGjgz004Bv4P8yqJGp9pyyqb",
             "analysis-GGjgz0j4Bv4P8yqJGp9pyyv2",
         ]
 
-        assert (
-            sorted(jobs) == analysis_1_jobs
-        ), "Failed to get analysis_1 dependent jobs"
+        assert sorted(jobs) == analysis_1_jobs, (
+            "Failed to get analysis_1 dependent jobs"
+        )
 
     def test_per_run_get_all_jobs(self):
         """
@@ -796,9 +751,7 @@ class TestGetDependentJobs:
         """
         params = {"depends_on": ["analysis_1", "analysis_2", "analysis_3"]}
 
-        jobs = get_dependent_jobs(
-            params=params, job_outputs_dict=self.job_outputs_dict
-        )
+        jobs = get_dependent_jobs(params=params, job_outputs_dict=self.job_outputs_dict)
 
         all_jobs = [
             "analysis-GGjgz004Bv4P8yqJGp9pyyqb",
@@ -818,13 +771,11 @@ class TestGetDependentJobs:
         """
         params = {"depends_on": ["analysis_5"]}
 
-        jobs = get_dependent_jobs(
-            params=params, job_outputs_dict=self.job_outputs_dict
-        )
+        jobs = get_dependent_jobs(params=params, job_outputs_dict=self.job_outputs_dict)
 
-        assert (
-            jobs == []
-        ), "Getting dependent jobs for absent analyis_ did not return an empty list"
+        assert jobs == [], (
+            "Getting dependent jobs for absent analyis_ did not return an empty list"
+        )
 
     def test_absent_analysis_does_not_raise_error_per_sample(self):
         """
@@ -840,9 +791,9 @@ class TestGetDependentJobs:
             sample="2207155-22207Z0091-1-BM-MPD-MYE-M-EGG2",
         )
 
-        assert (
-            jobs == []
-        ), "Getting dependent jobs for absent analyis_ did not return an empty list"
+        assert jobs == [], (
+            "Getting dependent jobs for absent analyis_ did not return an empty list"
+        )
 
 
 class TestLinkInputsToOutputs:
@@ -946,9 +897,9 @@ class TestLinkInputsToOutputs:
             },
         ]
 
-        assert (
-            output_input_dict == correct_input
-        ), "job IDs for all analysis_1 jobs not correctly parsed"
+        assert output_input_dict == correct_input, (
+            "job IDs for all analysis_1 jobs not correctly parsed"
+        )
 
     def test_adding_one_sample_analysis_1(self):
         """
@@ -999,8 +950,7 @@ class TestLinkInputsToOutputs:
         ]
 
         assert (
-            output["stage-G9Z2B7Q41bQg2Jy40zVqqGg4.somalier_input"]
-            == correct_output
+            output["stage-G9Z2B7Q41bQg2Jy40zVqqGg4.somalier_input"] == correct_output
         ), "job ID for analysis 2 wrongly parsed as input"
 
 
@@ -1029,9 +979,7 @@ class TestFilterJobOutputsDict:
         # dict matching section as would be in config defining the stage
         # input and patterns to filter by
         inputs_filter = {
-            "stage-G9Z2B8841bQY907z1ygq7K9x.somalier_extract_file": [
-                "Oncospan.*"
-            ]
+            "stage-G9Z2B8841bQY907z1ygq7K9x.somalier_extract_file": ["Oncospan.*"]
         }
 
         # get the jobs for Oncospan sample
@@ -1047,9 +995,9 @@ class TestFilterJobOutputsDict:
             }
         }
 
-        assert (
-            filtered_output == correct_output
-        ), "Filtering outputs dict with filter_job_outputs_dict() incorrect"
+        assert filtered_output == correct_output, (
+            "Filtering outputs dict with filter_job_outputs_dict() incorrect"
+        )
 
     def test_filter_multiple_patterns(self):
         """
@@ -1080,9 +1028,9 @@ class TestFilterJobOutputsDict:
             },
         }
 
-        assert (
-            filtered_output == correct_output
-        ), "Filtering outputs dict with filter_job_outputs_dict() incorrect"
+        assert filtered_output == correct_output, (
+            "Filtering outputs dict with filter_job_outputs_dict() incorrect"
+        )
 
 
 class TestFixInvalidInputs:
@@ -1176,18 +1124,16 @@ class TestFixInvalidInputs:
         """
         output = fix_invalid_inputs(
             input_dict=self.test_input_dict1,
-            input_classes=self.input_classes[
-                "workflow-GB12vxQ433GygFZK6pPF75q8"
-            ],
+            input_classes=self.input_classes["workflow-GB12vxQ433GygFZK6pPF75q8"],
         )
 
         input_type = type(
             output["stage-G9Z2B8841bQY907z1ygq7K9x.somalier_extract_file"]
         )
 
-        assert (
-            input_type == list
-        ), "array:file input not converted to a list as expected"
+        assert input_type == list, (
+            "array:file input not converted to a list as expected"
+        )
 
     def test_file_input_with_array_length_one_given(self):
         """
@@ -1196,14 +1142,10 @@ class TestFixInvalidInputs:
         """
         output = fix_invalid_inputs(
             input_dict=self.test_input_dict2,
-            input_classes=self.input_classes[
-                "workflow-GB12vxQ433GygFZK6pPF75q8"
-            ],
+            input_classes=self.input_classes["workflow-GB12vxQ433GygFZK6pPF75q8"],
         )
 
-        input_type = type(
-            output["stage-G9Z2B7Q41bQg2Jy40zVqqGg4.somalier_input"]
-        )
+        input_type = type(output["stage-G9Z2B7Q41bQg2Jy40zVqqGg4.somalier_input"])
 
         assert input_type == dict, "Input type not correctly set to dict"
 
@@ -1215,9 +1157,7 @@ class TestFixInvalidInputs:
         with pytest.raises(RuntimeError):
             fix_invalid_inputs(
                 input_dict=self.test_input_dict3,
-                input_classes=self.input_classes[
-                    "workflow-GB12vxQ433GygFZK6pPF75q8"
-                ],
+                input_classes=self.input_classes["workflow-GB12vxQ433GygFZK6pPF75q8"],
             )
 
     def test_unknown_input_field(self):
@@ -1481,3 +1421,108 @@ class TestPopulateTso500ReportsWorkflow(unittest.TestCase):
                 all_output_files=self.all_output_files,
                 job_output_ids=missing_files,
             )
+
+
+class TestIsHeld:
+    """
+    Tests for is_held() that checks a config dict for presence of
+    "hold" key with value True (bool or str) at any level of nesting
+    """
+
+    def test_no_hold_key(self):
+        """Test when no hold key anywhere"""
+        config = {"foo": 10, "bar": {"baz": 20}}
+        assert not is_held(config)
+
+    def test_hold_false_bool(self):
+        """Test when hold key==False"""
+        config = {"hold": False}
+        assert not is_held(config)
+
+    def test_hold_true_bool(self):
+        """Test when hold key==True"""
+        config = {"hold": True}
+        assert is_held(config)
+
+    def test_hold_true_str(self):
+        """Test when hold key=='True' string"""
+        config = {"hold": "true"}
+        assert is_held(config)
+
+    def test_hold_false_str(self):
+        """Test when hold key=='False' string"""
+        config = {"hold": "false"}
+        assert not is_held(config)
+
+    def test_nested_hold_true(self):
+        """Test when hold key is nested and True bool"""
+        config = {"foo": {"bar": {"hold": True}}}
+        assert is_held(config)
+
+    def test_nested_hold_true_str(self):
+        """Test when hold key is nested and True str"""
+        config = {
+            "foo": {
+                "bar": {
+                    "app": "app-id",
+                    "executable": {"name": "app-name", "hold": "true"},
+                }
+            }
+        }
+        assert is_held(config)
+
+    def test_very_nested_hold_true_str(self):
+        """Test when hold key is very nested and True bool"""
+        config = {"foo": {"bar": {"hold": "true"}}}
+        assert is_held(config)
+
+    def test_list_of_dicts_with_hold(self):
+        """Test when hold key is nested in list with True and False bool"""
+        config = {"foo": [{"hold": True}, {"hold": False}]}
+        assert is_held(config)
+
+    def test_key_ending_with_hold_is_not_used(self):
+        """Test when key ends with 'hold' but is not 'hold'"""
+        config = {"foo": [{"threshold": True}]}
+        assert not is_held(config)
+
+    def test_multiple_holds_one_true(self):
+        """Test when multiple hold keys and one is True"""
+        config = {"hold": False, "foo": {"hold": "true"}}
+        assert is_held(config)
+
+    def test_multiple_holds_all_false(self):
+        """Test when multiple hold keys and all are False"""
+        config = {"hold": False, "foo": {"hold": "false"}}
+        assert not is_held(config)
+
+    def test_only_hold_key_is_int(self):
+        """Test when only hold key and is int"""
+        config = {"hold": 10}
+        assert not is_held(config)
+
+    def test_hold_is_int(self):
+        """Test when multiple hold keys and one is int"""
+        config = {"hold": False, "foo": {"hold": 10}}
+        assert not is_held(config)
+
+    def test_hold_is_int_eq_true(self):
+        """
+        Test when multiple hold keys and one is int==1
+        expected to be False as only bool True or str 'true'
+        should be treated as hold
+        """
+        config = {"hold": False, "foo": {"hold": 1}}
+        assert not is_held(config)
+
+    def test_hold_is_int_eq_false(self):
+        """Test when multiple hold keys and one is int==0"""
+        config = {"hold": False, "foo": {"hold": 0}}
+        assert not is_held(config)
+
+    def test_hold_is_int_eq_false_but_true_present(self):
+        """Test when multiple hold keys and one is int==0
+        but another is True
+        """
+        config = {"hold": True, "foo": {"hold": 0}}
+        assert is_held(config)

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -1561,6 +1561,11 @@ class TestSearchExactKey:
         config = {"behold": "no", "foo": {"holdings": "nope"}}
         assert search_exact_key("hold", config) == []
 
+    def test_value_is_dictionary(self):
+        """Keys containing substring do not match"""
+        config = {"app": "app-id", "hold": {"value": True}}
+        assert search_exact_key("hold", config) == []
+
     def test_list_of_dicts(self):
         """List of dicts with matching key"""
         config = {"foo": [{"hold": 1}, {"hold": 2}]}

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -7,6 +7,7 @@ import pytest
 
 from utils.manage_dict import (
     search,
+    search_exact_key,
     replace,
     add_fastqs,
     add_upload_tars,
@@ -1526,3 +1527,42 @@ class TestIsHeld:
         """
         config = {"hold": True, "foo": {"hold": 0}}
         assert is_held(config)
+
+
+class TestSearchExactKey:
+    """
+    Tests for search_exact_key to ensure it matches only keys named exactly as the identifier,
+    regardless of nesting, and returns their values.
+    """
+
+    def test_no_match(self):
+        """No matching key present"""
+        config = {"foo": 1, "bar": {"baz": 2}}
+        assert search_exact_key("hold", config) == []
+
+    def test_top_level_match(self):
+        """Top-level key matches"""
+        config = {"hold": True, "foo": 1}
+        assert search_exact_key("hold", config) == [True]
+
+    def test_nested_match(self):
+        """Nested key matches"""
+        config = {"foo": {"hold": "yes"}}
+        assert search_exact_key("hold", config) == ["yes"]
+
+    def test_multiple_matches(self):
+        """Multiple keys match"""
+        config = {"hold": False, "foo": {"hold": True}}
+        result = search_exact_key("hold", config)
+        assert set(result) == {False, True}
+
+    def test_key_substring_not_match(self):
+        """Keys containing substring do not match"""
+        config = {"behold": "no", "foo": {"holdings": "nope"}}
+        assert search_exact_key("hold", config) == []
+
+    def test_list_of_dicts(self):
+        """List of dicts with matching key"""
+        config = {"foo": [{"hold": 1}, {"hold": 2}]}
+        result = search_exact_key("hold", config)
+        assert set(result) == {1, 2}

--- a/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
+++ b/resources/home/dnanexus/run_workflows/utils/demultiplexing.py
@@ -317,11 +317,12 @@ def demultiplex(
         job.wait_on_done()
     except dx.exceptions.DXJobFailureError as err:
         # dx job error raised (i.e. failed, timed out, terminated)
+        job_id = job.id.replace("job-", "")
         job_url = (
-            f"platform.dnanexus.com/projects/"
+            f"https://platform.dnanexus.com/projects/"
             f"{demultiplex_project.replace('project-', '')}"
             "/monitor/job/"
-            f"{job.id}"
+            f"{job_id}"
         )
 
         Slack().send(

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1051,3 +1051,25 @@ def populate_tso500_reports_workflow(
         prettier_print("\nNo populating for TSO500 reports_workflow required")
 
     return modified_input_dict, missing_output_sample
+
+
+def is_held(config):
+    """
+    Check if a config has any 'hold' key set to True or "true" in
+    its nested structure
+    Parameters
+    ----------
+    config : dict
+        dict of the sequencing assay config to check for hold keys
+    Returns
+    -------
+    bool
+        True if any 'hold' key is set to True or "true", else False
+    """
+    # Find all keys named 'hold' in the nested config
+    found = search('hold', config, check_key=True, return_key=False)
+    # Check if any of those keys are set to True or "true" in found
+    for value in found:
+        if value is True or (isinstance(value, str) and value.lower() == "true"):
+            return True
+    return False

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1096,6 +1096,6 @@ def is_held(config: dict) -> bool:
     found = search_exact_key('hold', config)
     # Check if any of those keys are set to True or "true" in found
     for value in found:
-        if value is True or (isinstance(value, str) and value.lower() == "true"):
+        if value is True:
             return True
     return False

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -65,6 +65,32 @@ def search(identifier, input_dict, check_key, return_key) -> list:
     return list(set(found))
 
 
+def search_exact_key(identifier, input_dict) -> list:
+    """
+    Searches nested dictionary for keys that match exactly the identifier string.
+    Returns the values for those keys.
+
+    Parameters
+    ----------
+    identifier : str
+        key name to match exactly
+    input_dict : dict
+        dict of input parameters for calling workflow / app
+
+    Returns
+    -------
+    list : list of values for keys that match exactly
+    """
+    flattened_dict = flatten(input_dict, "|")
+    found = []
+    # Match the last part of the key path exactly
+    for key, value in flattened_dict.items():
+        last_key = key.split('|')[-1]
+        if re.fullmatch(rf"{re.escape(identifier)}", last_key):
+            found.append(value)
+    return list(set(found))
+
+
 def replace(
     input_dict, to_replace, replacement, search_key, replace_key
 ) -> dict:
@@ -1053,7 +1079,7 @@ def populate_tso500_reports_workflow(
     return modified_input_dict, missing_output_sample
 
 
-def is_held(config):
+def is_held(config: dict) -> bool:
     """
     Check if a config has any 'hold' key set to True or "true" in
     its nested structure
@@ -1067,7 +1093,7 @@ def is_held(config):
         True if any 'hold' key is set to True or "true", else False
     """
     # Find all keys named 'hold' in the nested config
-    found = search('hold', config, check_key=True, return_key=False)
+    found = search_exact_key('hold', config)
     # Check if any of those keys are set to True or "true" in found
     for value in found:
         if value is True or (isinstance(value, str) and value.lower() == "true"):

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1095,7 +1095,4 @@ def is_held(config: dict) -> bool:
     # Find all keys named 'hold' in the nested config
     found = search_exact_key('hold', config)
     # Check if any of those keys are set to True or "true" in found
-    for value in found:
-        if value is True:
-            return True
-    return False
+    return any(val is True for val in found)

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -1081,7 +1081,7 @@ def populate_tso500_reports_workflow(
 
 def is_held(config: dict) -> bool:
     """
-    Check if a config has any 'hold' key set to True or "true" in
+    Check if a config has any 'hold' key set to True boolean in
     its nested structure
     Parameters
     ----------
@@ -1090,7 +1090,7 @@ def is_held(config: dict) -> bool:
     Returns
     -------
     bool
-        True if any 'hold' key is set to True or "true", else False
+        True if any 'hold' key is set to True, else False
     """
     # Find all keys named 'hold' in the nested config
     found = search_exact_key('hold', config)

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -86,9 +86,21 @@ def search_exact_key(identifier: str, input_dict: dict) -> list:
     # Match the last part of the key path exactly
     for key, value in flattened_dict.items():
         last_key = key.split('|')[-1]
-        if re.fullmatch(rf"{re.escape(identifier)}", last_key):
+        if last_key == identifier:
             found.append(value)
-    return list(set(found))
+    # Remove duplicates while preserving order and
+    # tolerate unhashable values
+    unique = []
+    seen = set()
+    for v in found:
+        try:
+            if v not in seen:
+                seen.add(v)
+                unique.append(v)
+        except TypeError:
+            unique.append(v)
+    return unique
+
 
 
 def replace(

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -65,7 +65,7 @@ def search(identifier, input_dict, check_key, return_key) -> list:
     return list(set(found))
 
 
-def search_exact_key(identifier, input_dict) -> list:
+def search_exact_key(identifier: str, input_dict: dict) -> list:
     """
     Searches nested dictionary for keys that match exactly the identifier string.
     Returns the values for those keys.

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -82,24 +82,15 @@ def search_exact_key(identifier: str, input_dict: dict) -> list:
     list : list of values for keys that match exactly
     """
     flattened_dict = flatten(input_dict, "|")
+    print(flattened_dict)
     found = []
     # Match the last part of the key path exactly
     for key, value in flattened_dict.items():
         last_key = key.split('|')[-1]
         if last_key == identifier:
             found.append(value)
-    # Remove duplicates while preserving order and
-    # tolerate unhashable values
-    unique = []
-    seen = set()
-    for v in found:
-        try:
-            if v not in seen:
-                seen.add(v)
-                unique.append(v)
-        except TypeError:
-            unique.append(v)
-    return unique
+
+    return list(set(found))
 
 
 

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -82,7 +82,7 @@ def search_exact_key(identifier: str, input_dict: dict) -> list:
     list : list of values for keys that match exactly
     """
     flattened_dict = flatten(input_dict, "|")
-    print(flattened_dict)
+
     found = []
     # Match the last part of the key path exactly
     for key, value in flattened_dict.items():


### PR DESCRIPTION
PR for fixing https://github.com/eastgenomics/eggd_conductor/issues/172 and https://github.com/eastgenomics/eggd_conductor/issues/169.

Changed the processing order of the assay handlers by sorting `hold=false` first.

Successful job: https://platform.dnanexus.com/panx/projects/J2Z7KF043bx7Kb25J99zzvPy/monitor/job/J2gV2v043bxBqP9K8pK6Z344

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/175)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added helpers to detect "hold" flags and to search exact keys in nested configurations; held items are processed last.

- Bug Fixes
  - Ticket, job and platform links now use HTTPS and canonical job IDs/paths for reliable linking.

- Tests
  - New tests covering hold detection and exact-key matching across nested structures.

- Documentation
  - Example URLs in README updated to use HTTPS.

- Chores
  - Application version bumped to 2.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->