### PR TITLE
Di 3529 modify code to handle the new helios config

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
   "name": "eggd_conductor",
   "title": "eggd_conductor",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "summary": "eggd_conductor",
   "dxapi": "1.0.0",
   "inputSpec": [
@@ -177,10 +177,10 @@
     "network": [
       "*"
     ],
-    "allProjects":"CONTRIBUTE",
+    "allProjects": "CONTRIBUTE",
     "project": "CONTRIBUTE"
   },
-  "developers":[
+  "developers": [
     "org-emee_1"
   ],
   "authorizedUsers": [

--- a/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/tests/test_manage_dict.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 import json
 import os
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -973,6 +974,13 @@ class TestFilterJobOutputsDict:
         "analysis_2": "job-GGjgz1j4Bv48yF89GpZ6zkGz",
     }
 
+    # example of stage input for query_vcf for happy
+    stage_input = {
+        "analysis": "analysis_1",
+        "stage": "stage-sentieon_dnaseq",
+        "field": "variants_vcf"
+    }
+
     def test_filter_job_outputs_dict_one_pattern(self):
         """
         Test filtering job outputs -> inputs dict by given pattern(s)
@@ -988,6 +996,7 @@ class TestFilterJobOutputsDict:
             stage="stage-G9Z2B8841bQY907z1ygq7K9x.somalier_extract_file",
             outputs_dict=self.job_outputs_dict,
             filter_dict=inputs_filter,
+            filter_type=self.stage_input,
         )
 
         correct_output = {
@@ -1018,6 +1027,7 @@ class TestFilterJobOutputsDict:
             stage="stage-G9Z2B8841bQY907z1ygq7K9x.somalier_extract_file",
             outputs_dict=self.job_outputs_dict,
             filter_dict=inputs_filter,
+            filter_type=self.stage_input,
         )
 
         correct_output = {
@@ -1031,6 +1041,42 @@ class TestFilterJobOutputsDict:
 
         assert filtered_output == correct_output, (
             "Filtering outputs dict with filter_job_outputs_dict() incorrect"
+        )
+
+    @patch("utils.manage_dict.filter_job_output")
+    def test_filter_job_output(self, mock_job_output):
+        mock_job_output.return_value = {
+            "project": "project-id", "id": "file-id"
+        }
+
+        job_outputs_dict = {"analysis_1": "job-id"}
+
+        inputs_filter = {
+            "query_vcf": [
+                "NA12878.*",
+                "-[0-9]+Q[0-9]+-"
+            ]
+        }
+
+        stage_input = {
+            "analysis": "analysis_1",
+            "job": "eggd_tso500",
+            "field": "gvcfs"
+        }
+
+        filtered_output = filter_job_outputs_dict(
+            stage="query_vcf",
+            outputs_dict=job_outputs_dict,
+            filter_dict=inputs_filter,
+            filter_type=stage_input,
+        )
+
+        correct_output = {
+            "$dnanexus_link": {"project": "project-id", "id": "file-id"}
+        }
+
+        assert filtered_output == correct_output, (
+            "The filtering of the job output is not functioning correctly"
         )
 
 

--- a/resources/home/dnanexus/run_workflows/utils/dx_utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_utils.py
@@ -402,8 +402,8 @@ def filter_job_output(job_id: str, patterns: list, field: str):
 
     links_to_files = job.describe()["output"][field]
 
-    for _, output_info in links_to_files.items():
-        for file_id in output_info.values():
+    for output_info in links_to_files:
+        for _, file_id in output_info.values():
             file = dx.DXFile(file_id)
 
             for pattern in patterns:

--- a/resources/home/dnanexus/run_workflows/utils/dx_utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_utils.py
@@ -381,7 +381,7 @@ def wait_on_done(analysis, analysis_name, all_job_ids) -> None:
 
 
 def filter_job_output(job_id: str, patterns: list, field: str):
-    """Filter the outputs to grab a specific DNAnexus file
+    """Get a specific file from a job using patterns and an output field
 
     Parameters
     ----------

--- a/resources/home/dnanexus/run_workflows/utils/dx_utils.py
+++ b/resources/home/dnanexus/run_workflows/utils/dx_utils.py
@@ -380,6 +380,42 @@ def wait_on_done(analysis, analysis_name, all_job_ids) -> None:
     print("All jobs to wait on completed")
 
 
+def filter_job_output(job_id: str, patterns: list, field: str):
+    """Filter the outputs to grab a specific DNAnexus file
+
+    Parameters
+    ----------
+    job_id : str
+        Job id to look at
+    patterns : list
+        Patterns to filter with
+    field : str
+        Output field to look into for files
+
+    Returns
+    -------
+    dict
+        Dict containing the project and file ids
+    """
+
+    job = dx.DXJob(job_id)
+
+    links_to_files = job.describe()["output"][field]
+
+    for _, output_info in links_to_files.items():
+        for file_id in output_info.values():
+            file = dx.DXFile(file_id)
+
+            for pattern in patterns:
+                if re.search(pattern, file.name):
+                    return {
+                        "project": file.project,
+                        "id": file.id,
+                    }
+
+    return
+
+
 def terminate_jobs(jobs) -> None:
     """
     Terminate all launched jobs in testing mode

--- a/resources/home/dnanexus/run_workflows/utils/manage_dict.py
+++ b/resources/home/dnanexus/run_workflows/utils/manage_dict.py
@@ -15,7 +15,7 @@ sys.path.append(
     os.path.abspath(os.path.join(os.path.realpath(__file__), "../../"))
 )
 
-from utils.dx_utils import get_job_out_folder
+from utils.dx_utils import get_job_out_folder, filter_job_output
 from utils.utils import prettier_print
 from utils.WebClasses import Slack
 
@@ -86,12 +86,11 @@ def search_exact_key(identifier: str, input_dict: dict) -> list:
     found = []
     # Match the last part of the key path exactly
     for key, value in flattened_dict.items():
-        last_key = key.split('|')[-1]
+        last_key = key.split("|")[-1]
         if last_key == identifier:
             found.append(value)
 
     return list(set(found))
-
 
 
 def replace(
@@ -689,17 +688,10 @@ def link_inputs_to_outputs(
 
                     # filter job outputs to search by sample name patterns
                     job_outputs_dict_copy = filter_job_outputs_dict(
-                        stage=input_field,
                         outputs_dict=job_outputs_dict,
                         filter_dict=input_filter_dict,
-                    )
-
-                    # gather all job IDs for current analysis ID
-                    job_ids = search(
-                        identifier=analysis_id,
-                        input_dict=job_outputs_dict_copy,
-                        check_key=True,
-                        return_key=False,
+                        stage=input_field,
+                        filter_type=stage_input,
                     )
 
                     # copy input structure from input dict, turn into an array
@@ -707,18 +699,32 @@ def link_inputs_to_outputs(
                     stage_input_template = deepcopy(link_dict)
                     modified_input_dict[input_field] = []
 
-                    for job in job_ids:
-                        stage_input_tmp = deepcopy(stage_input_template)
-                        stage_input_tmp = replace(
-                            input_dict=stage_input_tmp,
-                            to_replace=analysis_id,
-                            replacement=job,
-                            search_key=False,
-                            replace_key=False,
+                    # check whether we have a file reference or a job reference
+                    if "$dnanexus_link" in job_outputs_dict_copy:
+                        modified_input_dict[input_field] = (
+                            job_outputs_dict_copy
                         )
-                        modified_input_dict[input_field].append(
-                            stage_input_tmp
+                    else:
+                        # gather all job IDs for current analysis ID
+                        job_ids = search(
+                            identifier=analysis_id,
+                            input_dict=job_outputs_dict_copy,
+                            check_key=True,
+                            return_key=False,
                         )
+
+                        for job in job_ids:
+                            stage_input_tmp = deepcopy(stage_input_template)
+                            stage_input_tmp = replace(
+                                input_dict=stage_input_tmp,
+                                to_replace=analysis_id,
+                                replacement=job,
+                                search_key=False,
+                                replace_key=False,
+                            )
+                            modified_input_dict[input_field].append(
+                                stage_input_tmp
+                            )
 
     diff_res = list(diff(modified_input_dict, input_dict))
 
@@ -731,7 +737,9 @@ def link_inputs_to_outputs(
     return modified_input_dict
 
 
-def filter_job_outputs_dict(stage, outputs_dict, filter_dict) -> dict:
+def filter_job_outputs_dict(
+    outputs_dict: dict, filter_dict: dict, stage: str, filter_type: dict
+) -> dict:
     """
     Filter given dict of sample names -> job IDs to only keep job IDs
     of jobs for those sample(s) matching given pattern(s).
@@ -742,18 +750,22 @@ def filter_job_outputs_dict(stage, outputs_dict, filter_dict) -> dict:
 
     Parameters
     ----------
-    stage : str
-        stage ID to select patterns from filter_dict by
     outputs_dict : dict
         dict of sample IDs -> launched jobs
     filter_dict : dict
         mapping of stage_ID.inputs to a list of regex pattern(s) to
         filter sample IDs by
+    stage : str
+        stage ID to select patterns from filter_dict by
+    filter_type : dict
+        dict containing the info that needs to be replaced from the assay
+        config
+
 
     Returns
     -------
     dict
-        filtered jobs dict
+        filtered jobs/file dict
     """
 
     if not filter_dict:
@@ -767,18 +779,30 @@ def filter_job_outputs_dict(stage, outputs_dict, filter_dict) -> dict:
     prettier_print(f"\nFilter dict:{filter_dict}")
 
     new_outputs = {}
-    stage_match = False
+    type_match = False
 
     for filter_stage, filter_patterns in filter_dict.items():
         if stage == filter_stage:
             # current stage has filter(s) to apply
-            stage_match = True
-            for pattern in filter_patterns:
-                for sample, job in outputs_dict.items():
-                    if re.search(pattern, sample):
-                        new_outputs[sample] = job
+            type_match = True
 
-    if not stage_match:
+            if "stage" in filter_type:
+                for pattern in filter_patterns:
+                    for sample, job in outputs_dict.items():
+                        if re.search(pattern, sample):
+                            new_outputs[sample] = job
+
+            elif "job" in filter_type:
+                # look for correct file in eggd_tso500 job
+                for analysis, job in outputs_dict.items():
+                    if analysis == filter_type["analysis"]:
+                        prettier_print(f"Filtering the job output: {job}")
+                        # filter the job output to get the correct file
+                        new_outputs["$dnanexus_link"] = filter_job_output(
+                            job, filter_patterns, filter_type["field"]
+                        )
+
+    if not type_match:
         # stage has no filters to apply => just return the outputs dict
         prettier_print(f"\nNo filters to apply for stage: {stage}")
         return outputs_dict
@@ -1096,6 +1120,6 @@ def is_held(config: dict) -> bool:
         True if any 'hold' key is set to True, else False
     """
     # Find all keys named 'hold' in the nested config
-    found = search_exact_key('hold', config)
+    found = search_exact_key("hold", config)
     # Check if any of those keys are set to True or "true" in found
     return any(val is True for val in found)


### PR DESCRIPTION
- Change `filter_job_outputs_dict` to handle a new input:
  - Adjust function to handle a new structure in the assay config file i.e. instead of capturing an analysis, we want to capture the output of a job
- Adjust `link_inputs_to_outputs` to handle the new output of `filter_job_outputs_dict`
- New function `filter_job_output`:
  - Given a job id, a pattern and an output field name, it will return the output of the job matching the pattern in the output field
- Change the unittests accordingly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_conductor/188)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow output linking now supports more precise stage-aware filtering, helping analyses connect to the right downstream inputs.
  * Output selection can now match filenames more reliably when multiple job results are available.

* **Bug Fixes**
  * Improved handling of linked outputs so the expected file is chosen more consistently.
  * Updated the app manifest version to 2.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->